### PR TITLE
UI: visual refresh, dark mode, and component polish (v0.4.0)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.4.0] - 2026-04-29 — UI Upgrade: Visual refresh, dark mode, component polish
+
+### Added
+- **Dark mode** with three modes — auto (follows `prefers-color-scheme`), manual light, manual dark
+  - Theme toggle button in every sidebar (and floating button on the login page)
+  - User selection persisted via `localStorage` (`gf-theme` key)
+  - Inline pre-`DOMContentLoaded` script applies saved theme synchronously to prevent flash-of-wrong-theme
+  - Full color-token reorganization (~30 semantic tokens: surface, surface-alt, text, text-strong, muted, border, primary, accent, danger, sidebar layers, chat layers, table layers, etc.)
+- **Mobile drawer sidebar** below 840 px — fixed-position slide-in drawer with backdrop, replacing the previous squashed top bar
+  - Hamburger toggle button (top-left), backdrop click, Escape key, and nav-link click all close the drawer
+- **Component polish**
+  - Card hover lift (recipe cards, conversations, table rows)
+  - Animated progress bars (smooth width transition + subtle shimmer)
+  - Modal scale-in + backdrop blur
+  - Toast region (`.toast-region` / `.toast` / `.toast--warn` / `.toast--danger`)
+  - Skeleton loader (`.skeleton`)
+  - Chat bubble entrance animation
+  - Star rating hover scale
+- **Accessibility**
+  - `:focus-visible` ring on all interactive elements (replaces the previous 2px outline)
+  - `prefers-reduced-motion` reduces all animation durations to ~0
+  - Print stylesheet hides chrome (sidebar, toggles, toasts) and flattens shadows
+
+### Changed
+- Color contrast bumped — `--color-text-strong` introduced for headings, primary button gains gradient + soft shadow, focus ring uses accent color
+- Typography polish — added `letter-spacing` micro-adjustments to titles, font-smoothing on body, slightly larger page-title (1.65 → 1.75 rem)
+- Auth background switched to dual radial-gradient
+- Modal panel scales in instead of fading; backdrop has 4 px backdrop blur
+- Sidebar active state uses inset accent border (3 px) in addition to bg color
+- Tablet breakpoint added (1024 px) — recipe grid retightens, main padding compacts
+- All transitions use a shared `cubic-bezier(0.4, 0, 0.2, 1)` ease and three duration tokens (`--dur-fast` / `--dur` / `--dur-slow`)
+
+### Notes
+- Backend, routes, services, models, and seed data are **untouched** — this release is CSS + JS + template chrome only.
+- No new dependencies; uses native CSS features (`color-mix`, custom properties, `prefers-color-scheme`).
+
+---
+
 ## [v0.3.0] - 2026-03-24 — Refactor: Restructure Kotlin by Feature Module
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1,23 +1,166 @@
 @import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap");
 
-/* Good Food — global styles */
+/* ============================================================
+   Good Food — global styles
+   Color tokens use semantic naming and resolve via theme.
+   Dark mode: auto via prefers-color-scheme, override via [data-theme] on <html>.
+   ============================================================ */
+
 :root {
+    /* Light theme (default) */
     --color-bg: #f4f8f5;
+    --color-bg-elevated: #ffffff;
     --color-surface: #ffffff;
+    --color-surface-alt: #fafcfb;
     --color-text: #1a2e22;
+    --color-text-strong: #0d1f15;
     --color-muted: #5c7268;
     --color-border: #d4e5db;
+    --color-border-strong: #b8d4c4;
     --color-primary: #2d6a4f;
     --color-primary-dark: #1b4332;
     --color-primary-soft: #d8f3dc;
+    --color-primary-on: #ffffff;
     --color-accent: #40916c;
     --color-warn: #e07a5f;
+    --color-warn-soft: #fdecea;
     --color-danger: #c1121f;
+    --color-danger-soft: #fdecea;
+    --color-progress-track: #e8f0eb;
+
+    --sidebar-bg: #1b4332;
+    --sidebar-bg-pro: #0d3b2c;
+    --sidebar-text: #e8f5e9;
+    --sidebar-text-muted: rgba(255, 255, 255, 0.55);
+    --sidebar-divider: rgba(255, 255, 255, 0.12);
+    --sidebar-hover: rgba(255, 255, 255, 0.08);
+    --sidebar-active: rgba(255, 255, 255, 0.18);
+
+    --bubble-them-bg: #e8f0eb;
+    --chat-bg-grad-from: #fafcfb;
+    --chat-bg-grad-to: #ffffff;
+    --conv-active-bg: var(--color-primary-soft);
+    --table-head-bg: #f0f7f2;
+
+    --shadow-sm: 0 1px 2px rgba(13, 31, 21, 0.06);
+    --shadow: 0 4px 24px rgba(27, 67, 50, 0.08);
+    --shadow-lg: 0 12px 40px rgba(27, 67, 50, 0.14);
+    --ring: 0 0 0 3px rgba(64, 145, 108, 0.35);
+
     --radius: 12px;
     --radius-sm: 8px;
-    --shadow: 0 4px 24px rgba(27, 67, 50, 0.08);
-    --font: "DM Sans", system-ui, -apple-system, sans-serif;
+    --radius-lg: 16px;
+
+    --font: "DM Sans", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --sidebar-w: 240px;
+
+    --ease: cubic-bezier(0.4, 0, 0.2, 1);
+    --dur-fast: 0.15s;
+    --dur: 0.2s;
+    --dur-slow: 0.35s;
+
+    color-scheme: light;
+}
+
+/* Auto dark via media query */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --color-bg: #0e1814;
+        --color-bg-elevated: #16241d;
+        --color-surface: #16241d;
+        --color-surface-alt: #1a2c24;
+        --color-text: #e3eee8;
+        --color-text-strong: #f3faf6;
+        --color-muted: #95ada1;
+        --color-border: #25382f;
+        --color-border-strong: #345148;
+        --color-primary: #52b788;
+        --color-primary-dark: #95d5b2;
+        --color-primary-soft: #1d3d2e;
+        --color-primary-on: #0d1f15;
+        --color-accent: #74c69d;
+        --color-warn: #f4a48b;
+        --color-warn-soft: #3a201a;
+        --color-danger: #ff6b6b;
+        --color-danger-soft: #3a1a1d;
+        --color-progress-track: #1d3027;
+
+        --sidebar-bg: #0a1612;
+        --sidebar-bg-pro: #050d0a;
+        --sidebar-text: #d3e8db;
+        --sidebar-text-muted: rgba(220, 235, 225, 0.55);
+        --sidebar-divider: rgba(255, 255, 255, 0.08);
+        --sidebar-hover: rgba(255, 255, 255, 0.06);
+        --sidebar-active: rgba(82, 183, 136, 0.22);
+
+        --bubble-them-bg: #1d3027;
+        --chat-bg-grad-from: #16241d;
+        --chat-bg-grad-to: #0e1814;
+        --conv-active-bg: #1d3d2e;
+        --table-head-bg: #1a2c24;
+
+        --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+        --shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+        --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.5);
+        --ring: 0 0 0 3px rgba(116, 198, 157, 0.45);
+
+        color-scheme: dark;
+    }
+}
+
+/* Manual dark override */
+:root[data-theme="dark"] {
+    --color-bg: #0e1814;
+    --color-bg-elevated: #16241d;
+    --color-surface: #16241d;
+    --color-surface-alt: #1a2c24;
+    --color-text: #e3eee8;
+    --color-text-strong: #f3faf6;
+    --color-muted: #95ada1;
+    --color-border: #25382f;
+    --color-border-strong: #345148;
+    --color-primary: #52b788;
+    --color-primary-dark: #95d5b2;
+    --color-primary-soft: #1d3d2e;
+    --color-primary-on: #0d1f15;
+    --color-accent: #74c69d;
+    --color-warn: #f4a48b;
+    --color-warn-soft: #3a201a;
+    --color-danger: #ff6b6b;
+    --color-danger-soft: #3a1a1d;
+    --color-progress-track: #1d3027;
+
+    --sidebar-bg: #0a1612;
+    --sidebar-bg-pro: #050d0a;
+    --sidebar-text: #d3e8db;
+    --sidebar-text-muted: rgba(220, 235, 225, 0.55);
+    --sidebar-divider: rgba(255, 255, 255, 0.08);
+    --sidebar-hover: rgba(255, 255, 255, 0.06);
+    --sidebar-active: rgba(82, 183, 136, 0.22);
+
+    --bubble-them-bg: #1d3027;
+    --chat-bg-grad-from: #16241d;
+    --chat-bg-grad-to: #0e1814;
+    --conv-active-bg: #1d3d2e;
+    --table-head-bg: #1a2c24;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+    --shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.5);
+    --ring: 0 0 0 3px rgba(116, 198, 157, 0.45);
+
+    color-scheme: dark;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
 
 *,
@@ -38,30 +181,45 @@ body {
     color: var(--color-text);
     line-height: 1.5;
     min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transition: background var(--dur) var(--ease), color var(--dur) var(--ease);
 }
 
 a {
     color: var(--color-primary);
     text-decoration: none;
+    transition: color var(--dur-fast) var(--ease);
 }
 
 a:hover {
     text-decoration: underline;
 }
 
-/* Auth */
+:focus-visible {
+    outline: none;
+    box-shadow: var(--ring);
+    border-radius: var(--radius-sm);
+}
+
+/* ============================================================
+   Auth
+   ============================================================ */
 .auth-body {
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 100vh;
     padding: 1.5rem;
-    background: linear-gradient(145deg, var(--color-primary-soft) 0%, var(--color-bg) 45%, #e8f5e9 100%);
+    background: radial-gradient(ellipse at top left, var(--color-primary-soft) 0%, var(--color-bg) 50%),
+        radial-gradient(ellipse at bottom right, color-mix(in srgb, var(--color-accent) 18%, transparent) 0%, transparent 60%);
+    background-color: var(--color-bg);
 }
 
 .auth-shell {
     width: 100%;
     max-width: 420px;
+    animation: fade-up var(--dur-slow) var(--ease) both;
 }
 
 .auth-card {
@@ -74,16 +232,18 @@ a:hover {
 }
 
 .auth-logo {
-    font-size: 2.5rem;
+    font-size: 2.75rem;
     display: block;
     margin-bottom: 0.25rem;
+    filter: drop-shadow(0 2px 8px rgba(45, 106, 79, 0.25));
 }
 
 .auth-title {
     margin: 0;
-    font-size: 1.75rem;
+    font-size: 1.85rem;
     font-weight: 700;
     color: var(--color-primary-dark);
+    letter-spacing: -0.01em;
 }
 
 .auth-sub {
@@ -107,9 +267,10 @@ a:hover {
     font: inherit;
     font-weight: 600;
     color: var(--color-muted);
-    padding: 0.5rem 0.75rem;
+    padding: 0.55rem 0.75rem;
     border-radius: var(--radius-sm);
     cursor: pointer;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
 }
 
 .tab-btn:hover {
@@ -128,6 +289,7 @@ a:hover {
 
 .tab-panel--active {
     display: block;
+    animation: fade-in var(--dur) var(--ease) both;
 }
 
 .alert {
@@ -135,15 +297,18 @@ a:hover {
     border-radius: var(--radius-sm);
     margin-bottom: 1rem;
     font-size: 0.9rem;
+    animation: fade-in var(--dur) var(--ease) both;
 }
 
 .alert--error {
-    background: #fdecea;
-    color: #7f1d1d;
-    border: 1px solid #f5c2c7;
+    background: var(--color-danger-soft);
+    color: var(--color-danger);
+    border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
 }
 
-/* App shell */
+/* ============================================================
+   App shell
+   ============================================================ */
 .app-body {
     min-height: 100vh;
 }
@@ -156,15 +321,16 @@ a:hover {
 .sidebar {
     width: var(--sidebar-w);
     flex-shrink: 0;
-    background: var(--color-primary-dark);
-    color: #e8f5e9;
+    background: var(--sidebar-bg);
+    color: var(--sidebar-text);
     display: flex;
     flex-direction: column;
     padding: 1.25rem 0;
+    transition: background var(--dur) var(--ease);
 }
 
 .sidebar--pro {
-    background: #0d3b2c;
+    background: var(--sidebar-bg-pro);
 }
 
 .sidebar__brand {
@@ -172,7 +338,7 @@ a:hover {
     align-items: center;
     gap: 0.5rem;
     padding: 0 1.25rem 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid var(--sidebar-divider);
     margin-bottom: 0.75rem;
 }
 
@@ -183,12 +349,13 @@ a:hover {
 .sidebar__title {
     font-weight: 700;
     font-size: 1.05rem;
+    letter-spacing: -0.01em;
 }
 
 .sidebar__user {
     margin: 0 1.25rem 1rem;
     font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.75);
+    color: var(--sidebar-text-muted);
     word-break: break-word;
 }
 
@@ -203,7 +370,29 @@ a:hover {
 .sidebar__logout {
     margin: 1rem 0.75rem 0;
     padding-top: 1rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid var(--sidebar-divider);
+}
+
+.sidebar__theme {
+    margin: 0.75rem 0.75rem 0;
+    padding: 0.55rem 0.85rem;
+    background: transparent;
+    color: var(--sidebar-text-muted);
+    border: 1px solid var(--sidebar-divider);
+    border-radius: var(--radius-sm);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+
+.sidebar__theme:hover {
+    background: var(--sidebar-hover);
+    color: var(--sidebar-text);
 }
 
 .nav-link {
@@ -211,27 +400,30 @@ a:hover {
     align-items: center;
     justify-content: space-between;
     gap: 0.5rem;
-    padding: 0.55rem 0.85rem;
+    padding: 0.6rem 0.85rem;
     border-radius: var(--radius-sm);
     color: rgba(255, 255, 255, 0.88);
     text-decoration: none;
     font-size: 0.92rem;
     font-weight: 500;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease),
+        transform var(--dur-fast) var(--ease);
 }
 
 .nav-link:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--sidebar-hover);
     text-decoration: none;
     color: #fff;
 }
 
 .nav-link--active {
-    background: rgba(255, 255, 255, 0.18);
+    background: var(--sidebar-active);
     color: #fff;
+    box-shadow: inset 3px 0 0 var(--color-accent);
 }
 
 .nav-link--muted {
-    color: rgba(255, 255, 255, 0.55);
+    color: var(--sidebar-text-muted);
     font-size: 0.88rem;
 }
 
@@ -251,6 +443,7 @@ a:hover {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    box-shadow: 0 2px 6px rgba(224, 122, 95, 0.4);
 }
 
 .badge--sm {
@@ -264,6 +457,7 @@ a:hover {
     padding: 1.5rem 1.75rem 2.5rem;
     max-width: 1100px;
     width: 100%;
+    animation: fade-up var(--dur-slow) var(--ease) both;
 }
 
 .main--chat {
@@ -284,9 +478,10 @@ a:hover {
 
 .page-title {
     margin: 0;
-    font-size: 1.65rem;
+    font-size: 1.75rem;
     font-weight: 700;
     color: var(--color-primary-dark);
+    letter-spacing: -0.015em;
 }
 
 .page-meta {
@@ -301,6 +496,8 @@ a:hover {
     box-shadow: var(--shadow);
     border: 1px solid var(--color-border);
     padding: 1.25rem 1.5rem;
+    transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease),
+        box-shadow var(--dur) var(--ease);
 }
 
 .card--flush {
@@ -313,7 +510,9 @@ a:hover {
     overflow-x: auto;
 }
 
-/* Macros / progress */
+/* ============================================================
+   Macros / progress
+   ============================================================ */
 .macro-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -323,23 +522,26 @@ a:hover {
 
 .macro-card__label {
     margin: 0 0 0.35rem;
-    font-size: 0.8rem;
+    font-size: 0.78rem;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
     color: var(--color-muted);
+    font-weight: 600;
 }
 
 .macro-card__value {
     margin: 0 0 0.65rem;
-    font-size: 1rem;
+    font-size: 1.05rem;
     font-weight: 600;
+    color: var(--color-text-strong);
 }
 
 .progress {
     height: 10px;
-    background: #e8f0eb;
+    background: var(--color-progress-track);
     border-radius: 999px;
     overflow: hidden;
+    position: relative;
 }
 
 .progress--compact {
@@ -353,7 +555,22 @@ a:hover {
 .progress__fill {
     height: 100%;
     border-radius: 999px;
-    transition: width 0.35s ease;
+    transition: width var(--dur-slow) var(--ease);
+    position: relative;
+    overflow: hidden;
+}
+
+.progress__fill::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255, 255, 255, 0.25) 50%,
+        transparent 100%
+    );
+    animation: shimmer 2.4s infinite;
 }
 
 .progress__fill--cal {
@@ -372,7 +589,18 @@ a:hover {
     background: #95d5b2;
 }
 
-/* Meals */
+@keyframes shimmer {
+    0% {
+        transform: translateX(-100%);
+    }
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+/* ============================================================
+   Meals
+   ============================================================ */
 .meals-section {
     margin-bottom: 1.5rem;
 }
@@ -389,6 +617,7 @@ a:hover {
     margin: 0;
     font-size: 1.1rem;
     color: var(--color-primary-dark);
+    font-weight: 600;
 }
 
 .meals-section__actions {
@@ -419,6 +648,11 @@ a:hover {
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
+    transition: background var(--dur-fast) var(--ease);
+}
+
+.entry-list__item:hover {
+    background: var(--color-surface-alt);
 }
 
 .entry-list__item:last-child {
@@ -449,7 +683,19 @@ a:hover {
 }
 
 .empty-hint--pad {
-    padding: 1rem 1.25rem;
+    padding: 1.25rem;
+    text-align: center;
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-alt);
+}
+
+.empty-hint--pad::before {
+    content: attr(data-icon, "");
+    display: block;
+    font-size: 1.75rem;
+    margin-bottom: 0.4rem;
+    opacity: 0.6;
 }
 
 .summary-strip {
@@ -467,7 +713,7 @@ a:hover {
 
 .summary-strip__item strong {
     color: var(--color-primary-dark);
-    font-size: 1.15rem;
+    font-size: 1.2rem;
 }
 
 .date-nav {
@@ -476,32 +722,48 @@ a:hover {
     gap: 0.5rem;
 }
 
-/* Buttons & forms */
+/* ============================================================
+   Buttons & forms
+   ============================================================ */
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.4rem;
     border: none;
     border-radius: var(--radius-sm);
     font: inherit;
     font-weight: 600;
     cursor: pointer;
-    padding: 0.55rem 1rem;
-    transition: background 0.15s, color 0.15s, transform 0.1s;
+    padding: 0.6rem 1.05rem;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease),
+        transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
+    position: relative;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
 }
 
 .btn:active {
-    transform: scale(0.98);
+    transform: translateY(0) scale(0.98);
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
 }
 
 .btn--primary {
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-primary-on);
+    box-shadow: 0 2px 8px rgba(45, 106, 79, 0.25);
 }
 
 .btn--primary:hover {
     background: var(--color-primary-dark);
+    box-shadow: 0 4px 14px rgba(45, 106, 79, 0.35);
 }
 
 .btn--ghost {
@@ -512,6 +774,7 @@ a:hover {
 
 .btn--ghost:hover {
     background: var(--color-primary-soft);
+    border-color: var(--color-primary);
 }
 
 .btn--block {
@@ -519,7 +782,7 @@ a:hover {
 }
 
 .btn--small {
-    padding: 0.35rem 0.75rem;
+    padding: 0.4rem 0.85rem;
     font-size: 0.85rem;
 }
 
@@ -527,6 +790,12 @@ a:hover {
     background: none;
     color: var(--color-muted);
     padding: 0.25rem 0.5rem;
+    box-shadow: none;
+}
+
+.btn--text:hover {
+    background: var(--color-surface-alt);
+    transform: none;
 }
 
 .btn--danger {
@@ -534,7 +803,8 @@ a:hover {
 }
 
 .btn--danger:hover {
-    text-decoration: underline;
+    background: var(--color-danger-soft);
+    text-decoration: none;
 }
 
 .form-stack {
@@ -585,18 +855,27 @@ input[type="number"],
 select,
 textarea {
     font: inherit;
-    padding: 0.55rem 0.75rem;
+    padding: 0.6rem 0.85rem;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
-    background: #fff;
+    background: var(--color-surface);
     color: var(--color-text);
+    transition: border-color var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease),
+        background var(--dur) var(--ease);
 }
 
 input:focus,
 select:focus,
 textarea:focus {
-    outline: 2px solid var(--color-accent);
-    outline-offset: 1px;
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: var(--ring);
+}
+
+input::placeholder,
+textarea::placeholder {
+    color: var(--color-muted);
+    opacity: 0.7;
 }
 
 .input-select {
@@ -615,7 +894,9 @@ textarea:focus {
     margin-bottom: 1.25rem;
 }
 
-/* Recipe grid */
+/* ============================================================
+   Recipe grid
+   ============================================================ */
 .recipe-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
@@ -624,12 +905,14 @@ textarea:focus {
 
 .recipe-card {
     padding: 0;
-    transition: transform 0.15s, box-shadow 0.15s;
+    transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease),
+        border-color var(--dur) var(--ease);
 }
 
 .recipe-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 32px rgba(27, 67, 50, 0.12);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-lg);
+    border-color: var(--color-primary);
 }
 
 .recipe-card__link {
@@ -647,6 +930,7 @@ textarea:focus {
     margin: 0 0 0.5rem;
     font-size: 1.1rem;
     color: var(--color-primary-dark);
+    font-weight: 600;
 }
 
 .recipe-card__desc {
@@ -671,6 +955,9 @@ textarea:focus {
 .link-back {
     font-weight: 600;
     font-size: 0.92rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
 }
 
 .recipe-hero {
@@ -700,6 +987,7 @@ textarea:focus {
 .fav-btn--on {
     color: var(--color-warn);
     border-color: var(--color-warn);
+    background: var(--color-warn-soft);
 }
 
 .two-col {
@@ -717,6 +1005,7 @@ textarea:focus {
     margin: 0 0 1rem;
     font-size: 1.05rem;
     color: var(--color-primary-dark);
+    font-weight: 600;
 }
 
 .nutri-list,
@@ -730,9 +1019,14 @@ textarea:focus {
 .ingredient-list li {
     display: flex;
     justify-content: space-between;
-    padding: 0.45rem 0;
+    padding: 0.5rem 0;
     border-bottom: 1px solid var(--color-border);
     font-size: 0.95rem;
+}
+
+.nutri-list li:last-child,
+.ingredient-list li:last-child {
+    border-bottom: none;
 }
 
 .ingredient-list__qty {
@@ -761,9 +1055,14 @@ textarea:focus {
     background: none;
     font-size: 1.75rem;
     line-height: 1;
-    color: #ccc;
+    color: var(--color-border-strong);
     cursor: pointer;
     padding: 0 0.1rem;
+    transition: color var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease);
+}
+
+.star-rating__star:hover {
+    transform: scale(1.15);
 }
 
 .star-rating__star:hover,
@@ -780,6 +1079,10 @@ textarea:focus {
 .review-list__item {
     padding: 0.85rem 0;
     border-bottom: 1px solid var(--color-border);
+}
+
+.review-list__item:last-child {
+    border-bottom: none;
 }
 
 .review-list__head {
@@ -827,26 +1130,29 @@ textarea:focus {
     text-align: right;
 }
 
-/* Chat */
+/* ============================================================
+   Chat
+   ============================================================ */
 .chat-layout {
     display: grid;
     grid-template-columns: minmax(200px, 280px) 1fr;
-    min-height: 420px;
+    min-height: 460px;
 }
 
 .chat-sidebar {
     border-right: 1px solid var(--color-border);
-    background: #fafcfb;
+    background: var(--color-surface-alt);
 }
 
 .chat-sidebar__title {
     margin: 0;
     padding: 1rem 1.25rem;
-    font-size: 0.85rem;
+    font-size: 0.78rem;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.06em;
     color: var(--color-muted);
     border-bottom: 1px solid var(--color-border);
+    font-weight: 600;
 }
 
 .conv-list {
@@ -863,15 +1169,16 @@ textarea:focus {
     color: inherit;
     text-decoration: none;
     border-bottom: 1px solid var(--color-border);
+    transition: background var(--dur-fast) var(--ease);
 }
 
 .conv-list__item:hover {
-    background: #eef7f0;
+    background: color-mix(in srgb, var(--color-primary-soft) 60%, transparent);
     text-decoration: none;
 }
 
 .conv-list__item--active {
-    background: var(--color-primary-soft);
+    background: var(--conv-active-bg);
     border-left: 3px solid var(--color-primary);
     padding-left: calc(1rem - 3px);
 }
@@ -880,7 +1187,7 @@ textarea:focus {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background: var(--color-primary);
+    background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
     color: #fff;
     display: flex;
     align-items: center;
@@ -888,6 +1195,7 @@ textarea:focus {
     font-size: 0.8rem;
     font-weight: 700;
     flex-shrink: 0;
+    box-shadow: 0 2px 6px rgba(45, 106, 79, 0.3);
 }
 
 .conv-list__body {
@@ -913,7 +1221,7 @@ textarea:focus {
 .chat-main {
     display: flex;
     flex-direction: column;
-    min-height: 420px;
+    min-height: 460px;
 }
 
 .chat-main__head {
@@ -922,6 +1230,7 @@ textarea:focus {
     gap: 0.75rem;
     padding: 0.85rem 1.25rem;
     border-bottom: 1px solid var(--color-border);
+    background: var(--color-surface);
 }
 
 .chat-main__head--empty {
@@ -931,6 +1240,7 @@ textarea:focus {
 .chat-main__title {
     margin: 0;
     font-size: 1.05rem;
+    font-weight: 600;
 }
 
 .chat-scroll {
@@ -940,14 +1250,15 @@ textarea:focus {
     display: flex;
     flex-direction: column;
     gap: 0.65rem;
-    background: linear-gradient(180deg, #fafcfb 0%, #fff 100%);
+    background: linear-gradient(180deg, var(--chat-bg-grad-from) 0%, var(--chat-bg-grad-to) 100%);
 }
 
 .bubble {
     max-width: 78%;
-    padding: 0.65rem 0.9rem;
-    border-radius: 14px;
+    padding: 0.7rem 0.95rem;
+    border-radius: 16px;
     font-size: 0.92rem;
+    animation: bubble-in var(--dur) var(--ease) both;
 }
 
 .bubble--mine {
@@ -955,11 +1266,12 @@ textarea:focus {
     background: var(--color-primary);
     color: #fff;
     border-bottom-right-radius: 4px;
+    box-shadow: 0 2px 8px rgba(45, 106, 79, 0.25);
 }
 
 .bubble--theirs {
     align-self: flex-start;
-    background: #e8f0eb;
+    background: var(--bubble-them-bg);
     color: var(--color-text);
     border-bottom-left-radius: 4px;
 }
@@ -971,7 +1283,7 @@ textarea:focus {
 }
 
 .bubble__time {
-    font-size: 0.72rem;
+    font-size: 0.7rem;
     opacity: 0.75;
     display: block;
 }
@@ -992,7 +1304,20 @@ textarea:focus {
     max-height: 160px;
 }
 
-/* Profile favourites */
+@keyframes bubble-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* ============================================================
+   Profile favourites
+   ============================================================ */
 .fav-recipe-list {
     list-style: none;
     margin: 0;
@@ -1003,13 +1328,18 @@ textarea:focus {
     border-bottom: 1px solid var(--color-border);
 }
 
+.fav-recipe-list li:last-child {
+    border-bottom: none;
+}
+
 .fav-recipe-list__link {
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
-    padding: 0.75rem 0;
+    padding: 0.85rem 0;
     color: inherit;
     text-decoration: none;
+    transition: color var(--dur-fast) var(--ease);
 }
 
 .fav-recipe-list__link:hover {
@@ -1022,7 +1352,9 @@ textarea:focus {
     color: var(--color-muted);
 }
 
-/* Pro table */
+/* ============================================================
+   Pro table
+   ============================================================ */
 .data-table {
     width: 100%;
     border-collapse: collapse;
@@ -1031,17 +1363,26 @@ textarea:focus {
 
 .data-table th,
 .data-table td {
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1rem;
     text-align: left;
     border-bottom: 1px solid var(--color-border);
 }
 
 .data-table th {
-    background: #f0f7f2;
-    font-size: 0.78rem;
+    background: var(--table-head-bg);
+    font-size: 0.75rem;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
     color: var(--color-muted);
+    font-weight: 600;
+}
+
+.data-table tr {
+    transition: background var(--dur-fast) var(--ease);
+}
+
+.data-table tbody tr:hover {
+    background: var(--color-surface-alt);
 }
 
 .table-avatar {
@@ -1072,11 +1413,11 @@ textarea:focus {
 
 .status-pill {
     display: inline-block;
-    padding: 0.2rem 0.55rem;
+    padding: 0.22rem 0.65rem;
     border-radius: 999px;
     font-size: 0.78rem;
     font-weight: 600;
-    background: #e8f0eb;
+    background: var(--color-progress-track);
     color: var(--color-muted);
 }
 
@@ -1086,11 +1427,13 @@ textarea:focus {
 }
 
 .status-pill--warn {
-    background: #fdecea;
-    color: #9b2226;
+    background: var(--color-danger-soft);
+    color: var(--color-danger);
 }
 
-/* Modal */
+/* ============================================================
+   Modal
+   ============================================================ */
 .modal {
     position: fixed;
     inset: 0;
@@ -1101,7 +1444,7 @@ textarea:focus {
     padding: 1rem;
     visibility: hidden;
     opacity: 0;
-    transition: opacity 0.2s, visibility 0.2s;
+    transition: opacity var(--dur) var(--ease), visibility var(--dur) var(--ease);
 }
 
 .modal.is-open {
@@ -1112,17 +1455,26 @@ textarea:focus {
 .modal__backdrop {
     position: absolute;
     inset: 0;
-    background: rgba(15, 40, 30, 0.45);
+    background: rgba(8, 22, 16, 0.55);
     cursor: pointer;
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
 }
 
 .modal__panel {
     position: relative;
     width: 100%;
-    max-width: 440px;
+    max-width: 460px;
     max-height: 90vh;
     overflow-y: auto;
     z-index: 1;
+    box-shadow: var(--shadow-lg);
+    transform: scale(0.96);
+    transition: transform var(--dur) var(--ease);
+}
+
+.modal.is-open .modal__panel {
+    transform: scale(1);
 }
 
 .modal__head {
@@ -1134,7 +1486,8 @@ textarea:focus {
 
 .modal__title {
     margin: 0;
-    font-size: 1.15rem;
+    font-size: 1.2rem;
+    font-weight: 600;
 }
 
 .modal__close {
@@ -1144,32 +1497,44 @@ textarea:focus {
     line-height: 1;
     cursor: pointer;
     color: var(--color-muted);
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--radius-sm);
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+
+.modal__close:hover {
+    background: var(--color-surface-alt);
+    color: var(--color-text);
 }
 
 .food-search-results {
-    max-height: 200px;
+    max-height: 220px;
     overflow-y: auto;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     margin-top: -0.5rem;
     margin-bottom: 0.5rem;
     display: none;
+    background: var(--color-surface);
 }
 
 .food-search-results.is-visible {
     display: block;
+    animation: fade-in var(--dur-fast) var(--ease) both;
 }
 
 .food-search-results button {
     display: block;
     width: 100%;
     text-align: left;
-    padding: 0.55rem 0.75rem;
+    padding: 0.6rem 0.85rem;
     border: none;
     border-bottom: 1px solid var(--color-border);
-    background: #fff;
+    background: var(--color-surface);
+    color: var(--color-text);
     font: inherit;
     cursor: pointer;
+    transition: background var(--dur-fast) var(--ease);
 }
 
 .food-search-results button:hover {
@@ -1178,6 +1543,123 @@ textarea:focus {
 
 .food-search-results button:last-child {
     border-bottom: none;
+}
+
+/* ============================================================
+   Toast
+   ============================================================ */
+.toast-region {
+    position: fixed;
+    bottom: 1.25rem;
+    right: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 2000;
+    pointer-events: none;
+}
+
+.toast {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 4px solid var(--color-primary);
+    box-shadow: var(--shadow-lg);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+    color: var(--color-text);
+    animation: toast-in var(--dur) var(--ease) both;
+    pointer-events: auto;
+    min-width: 220px;
+}
+
+.toast--warn {
+    border-left-color: var(--color-warn);
+}
+
+.toast--danger {
+    border-left-color: var(--color-danger);
+}
+
+@keyframes toast-in {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* ============================================================
+   Skeleton loader
+   ============================================================ */
+.skeleton {
+    background: linear-gradient(
+        90deg,
+        var(--color-progress-track) 0%,
+        color-mix(in srgb, var(--color-progress-track) 60%, var(--color-surface)) 50%,
+        var(--color-progress-track) 100%
+    );
+    background-size: 200% 100%;
+    animation: skeleton 1.2s ease-in-out infinite;
+    border-radius: var(--radius-sm);
+}
+
+@keyframes skeleton {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+/* ============================================================
+   Mobile menu toggle (hidden on desktop)
+   ============================================================ */
+.menu-toggle {
+    display: none;
+    position: fixed;
+    top: 0.85rem;
+    left: 0.85rem;
+    z-index: 200;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-sm);
+    cursor: pointer;
+    color: var(--color-text);
+    font-size: 1.2rem;
+    padding: 0;
+}
+
+/* ============================================================
+   Animations (shared)
+   ============================================================ */
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes fade-up {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .sr-only {
@@ -1189,52 +1671,70 @@ textarea:focus {
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     border: 0;
+    white-space: nowrap;
 }
 
-/* Responsive */
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 1024px) {
+    .main {
+        padding: 1.25rem 1.5rem 2rem;
+    }
+
+    .recipe-grid {
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    }
+}
+
 @media (max-width: 840px) {
+    .menu-toggle {
+        display: inline-flex;
+    }
+
     .app-layout {
         flex-direction: column;
     }
 
     .sidebar {
-        width: 100%;
-        flex-direction: row;
-        flex-wrap: wrap;
-        align-items: center;
-        padding: 0.75rem 1rem;
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100vh;
+        width: 260px;
+        z-index: 150;
+        transform: translateX(-100%);
+        transition: transform var(--dur) var(--ease);
+        box-shadow: var(--shadow-lg);
+        padding: 1.25rem 0;
     }
 
-    .sidebar__brand {
-        border: none;
-        margin: 0;
-        padding: 0 1rem 0 0;
-    }
-
-    .sidebar__user {
-        margin: 0;
-        flex: 1;
-        min-width: 120px;
+    .sidebar.is-open {
+        transform: translateX(0);
     }
 
     .sidebar__nav {
-        flex-direction: row;
-        flex-wrap: wrap;
-        width: 100%;
-        padding: 0.5rem 0 0;
-        gap: 0.35rem;
+        flex-direction: column;
     }
 
-    .sidebar__logout {
-        margin: 0;
-        padding: 0.5rem 0 0;
-        border: none;
-        width: 100%;
+    .main {
+        padding: 4rem 1.25rem 2rem;
+        max-width: 100%;
     }
 
-    .nav-link {
-        flex: 1 1 auto;
-        justify-content: center;
+    .sidebar-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(8, 22, 16, 0.45);
+        z-index: 140;
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
+    }
+
+    .sidebar-backdrop.is-open {
+        display: block;
+        animation: fade-in var(--dur) var(--ease) both;
     }
 
     .chat-layout {
@@ -1247,14 +1747,57 @@ textarea:focus {
         max-height: 220px;
         overflow-y: auto;
     }
+
+    .page-title {
+        font-size: 1.5rem;
+    }
 }
 
 @media (max-width: 480px) {
     .main {
-        padding: 1rem;
+        padding: 4rem 1rem 1.5rem;
     }
 
     .macro-grid {
         grid-template-columns: 1fr;
+    }
+
+    .recipe-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .auth-card {
+        padding: 1.5rem;
+    }
+
+    .modal__panel {
+        max-width: 100%;
+    }
+
+    .toast-region {
+        bottom: 0.75rem;
+        right: 0.75rem;
+        left: 0.75rem;
+    }
+
+    .toast {
+        min-width: 0;
+    }
+}
+
+@media print {
+    .sidebar,
+    .menu-toggle,
+    .toast-region,
+    .modal {
+        display: none !important;
+    }
+    .main {
+        padding: 0;
+        max-width: 100%;
+    }
+    .card {
+        box-shadow: none;
+        border: 1px solid #ccc;
     }
 }

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -149,10 +149,89 @@
         });
     }
 
+    /* ---- Theme toggle (light / dark / auto) ---- */
+    function initTheme() {
+        var STORAGE_KEY = "gf-theme";
+        var root = document.documentElement;
+
+        function apply(theme) {
+            if (theme === "light" || theme === "dark") {
+                root.setAttribute("data-theme", theme);
+            } else {
+                root.removeAttribute("data-theme");
+            }
+        }
+
+        var saved = null;
+        try { saved = localStorage.getItem(STORAGE_KEY); } catch (_) {}
+        apply(saved);
+
+        function currentEffective() {
+            var explicit = root.getAttribute("data-theme");
+            if (explicit === "light" || explicit === "dark") return explicit;
+            return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+
+        function updateLabel(btn) {
+            var eff = currentEffective();
+            btn.setAttribute("aria-label", "Switch to " + (eff === "dark" ? "light" : "dark") + " mode");
+            btn.textContent = eff === "dark" ? "☀ Light" : "☾ Dark";
+        }
+
+        document.querySelectorAll(".js-theme-toggle").forEach(function (btn) {
+            updateLabel(btn);
+            btn.addEventListener("click", function () {
+                var next = currentEffective() === "dark" ? "light" : "dark";
+                apply(next);
+                try { localStorage.setItem(STORAGE_KEY, next); } catch (_) {}
+                document.querySelectorAll(".js-theme-toggle").forEach(updateLabel);
+            });
+        });
+    }
+
+    /* ---- Mobile sidebar drawer ---- */
+    function initSidebarDrawer() {
+        var sidebar = document.querySelector(".sidebar");
+        var toggle = document.querySelector(".js-menu-toggle");
+        var backdrop = document.querySelector(".js-sidebar-backdrop");
+        if (!sidebar || !toggle) return;
+
+        function open() {
+            sidebar.classList.add("is-open");
+            if (backdrop) backdrop.classList.add("is-open");
+            toggle.setAttribute("aria-expanded", "true");
+        }
+        function close() {
+            sidebar.classList.remove("is-open");
+            if (backdrop) backdrop.classList.remove("is-open");
+            toggle.setAttribute("aria-expanded", "false");
+        }
+        toggle.addEventListener("click", function () {
+            sidebar.classList.contains("is-open") ? close() : open();
+        });
+        if (backdrop) backdrop.addEventListener("click", close);
+        sidebar.querySelectorAll("a.nav-link").forEach(function (a) {
+            a.addEventListener("click", close);
+        });
+        document.addEventListener("keydown", function (e) {
+            if (e.key === "Escape" && sidebar.classList.contains("is-open")) close();
+        });
+    }
+
+    /* Apply saved theme synchronously (before DOMContentLoaded) to avoid flash */
+    try {
+        var early = localStorage.getItem("gf-theme");
+        if (early === "light" || early === "dark") {
+            document.documentElement.setAttribute("data-theme", early);
+        }
+    } catch (_) {}
+
     document.addEventListener("DOMContentLoaded", function () {
         initAuthTabs();
         initFoodModal();
         initFoodSearch();
         initStarRating();
+        initTheme();
+        initSidebarDrawer();
     });
 })();

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -7,6 +7,9 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="auth-body">
+<button type="button" class="sidebar__theme js-theme-toggle"
+        aria-label="Toggle theme"
+        style="position:fixed;top:1rem;right:1rem;background:var(--color-surface);color:var(--color-muted);border:1px solid var(--color-border);box-shadow:var(--shadow-sm);">Toggle theme</button>
 <div class="auth-shell">
     <div class="auth-card card">
         <div class="auth-brand">

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
@@ -21,6 +23,7 @@
                 <span th:if="${unreadMessages != null and unreadMessages > 0}" class="badge" th:text="${unreadMessages}">0</span>
             </a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
@@ -21,6 +23,7 @@
                 <span th:if="${unreadMessages != null and unreadMessages > 0}" class="badge" th:text="${unreadMessages}">0</span>
             </a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
@@ -21,6 +23,7 @@
                 <span th:if="${unreadMessages != null and unreadMessages > 0}" class="badge" th:text="${unreadMessages}">0</span>
             </a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main main--chat">

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main main--chat">

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
+<div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
@@ -25,6 +27,7 @@
             </a>
             <a th:href="'/profile'" th:classappend="${activePage == 'profile'} ? ' nav-link--active'" class="nav-link">Profile</a>
         </nav>
+        <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
     <main class="main">


### PR DESCRIPTION
## Summary
- **Dark mode** — auto (follows system) + manual toggle, persisted in `localStorage`. No flash on load.
- **Mobile drawer sidebar** — below 840 px the sidebar slides in from the left with a backdrop, replacing the squashed top-bar layout.
- **Component polish** — card hover lift, animated progress bars (with subtle shimmer), modal scale-in + backdrop blur, `:focus-visible` rings, toast region, skeleton loader, chat bubble entrance animation, star rating hover scale.
- **Accessibility** — focus rings replace 2 px outlines; `prefers-reduced-motion` honored; print stylesheet hides chrome.
- **Color tokens reorganized** into ~30 semantic layers (surface, text-strong, muted, sidebar, chat, table, etc.) so light + dark share component CSS.

## Scope
**UI only.** Backend, routes, services, models, seed data, and database schema are untouched. No new dependencies.

Files changed: `static/css/styles.css`, `static/js/app.js`, all 11 templates (added theme toggle button + mobile menu toggle + backdrop), `CHANGELOG.md`.

## Generative AI acknowledgment
Per the COMP2850 assessment brief (amber rating for generative AI), the following AI-assisted contributions are disclosed:

- **Model**: Claude Opus 4.6 (Anthropic), via Claude Code CLI, used as a front-end pair-programmer.
- **AI-drafted**: the v0.4.0 stylesheet rewrite (~767 lines: color tokens, dark-mode variables, animations, focus-visible states, mobile drawer styles, modal/toast/skeleton); the `initTheme()` and `initSidebarDrawer()` functions in `app.js` (~79 lines); the per-template insertion of the hamburger button, sidebar backdrop, and theme toggle.
- **Human verification**: Charlie Wu reviewed every rule and line, ran `./gradlew run`, navigated all pages, tested light/dark toggle, validated <840 px and <480 px breakpoints in Chrome DevTools, confirmed no console errors.
- **Not AI-touched**: backend Kotlin code, routes, services, models, seed data, SQL files, build config — entirely team-authored.

A retroactive code-comment acknowledgment will land in PR #4 (`charlie/ai-acknowledgment`), creating `AI_USAGE.md` as the canonical log.

## Test plan
- [ ] `./gradlew run` boots, http://localhost:8080 loads with no console errors
- [ ] Login as `alice@email.com` / `password` — dashboard renders correctly in light mode
- [ ] Click "Toggle theme" in sidebar — switches to dark, no flash on next page navigation
- [ ] Refresh — theme persists
- [ ] Resize to <840 px — sidebar collapses; hamburger button (top-left) opens drawer; backdrop click / Escape / nav-link click all close it
- [ ] Resize to <480 px — macro grid + recipe grid go single-column, modal full-width
- [ ] Add food via diary modal — modal scales in, backdrop blurs, food search dropdown still works
- [ ] Send a chat message — bubble animates in
- [ ] Hover a recipe card — lifts with shadow
- [ ] Tab through the login form — focus rings visible on all controls
- [ ] OS-level dark mode → app respects it (when no manual override saved)