### PR TITLE
chore: add Codespace devcontainer with JDK 17 (v0.4.1)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+    "name": "Good Food (Ktor + JDK 17)",
+    "image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "17",
+            "installGradle": false
+        }
+    },
+    "forwardPorts": [8080],
+    "portsAttributes": {
+        "8080": {
+            "label": "Good Food app",
+            "onAutoForward": "openBrowser"
+        }
+    },
+    "postCreateCommand": "cd \"2850final project\" && chmod +x gradlew && ./gradlew --version",
+    "remoteUser": "vscode",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "fwcd.kotlin",
+                "vscjava.vscode-gradle",
+                "redhat.vscode-thymeleaf"
+            ]
+        }
+    }
+}

--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.4.1] - 2026-04-29 — Codespace / dev container config
+
+### Added
+- `.devcontainer/devcontainer.json` — pins JDK 17 (matches `build.gradle.kts` `jvmToolchain(17)`) so GitHub Codespaces and VS Code Dev Containers boot ready to run `./gradlew run` with no manual `apt-get install` or JDK switching.
+  - Base image: `mcr.microsoft.com/devcontainers/java:1-17-bookworm`
+  - Port `8080` auto-forwarded with `openBrowser` on first start
+  - `postCreateCommand` warms the Gradle daemon so the first build is faster
+  - Pre-installs Kotlin, Gradle, and Thymeleaf VS Code extensions
+
+### Notes
+- No code changes — config-only.
+- Existing local dev workflow (`./gradlew run` with a system JDK 17) is unaffected.
+
+---
+
 ## [v0.4.0] - 2026-04-29 — UI Upgrade: Visual refresh, dark mode, component polish
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json` so Codespaces and VS Code Dev Containers boot with JDK 17 ready (matches `build.gradle.kts` `jvmToolchain(17)`).
- No more manual `apt-get install openjdk-17-jdk` when opening a fresh Codespace.
- Auto-forwards port 8080 and opens the browser on first start.
- Pre-installs Kotlin, Gradle, and Thymeleaf VS Code extensions.

## Why
Opening a Codespace today picks up whatever JDK the base image ships (currently 25), which Gradle 8.5 + the project's toolchain config rejects. Every new Codespace required a manual JDK install before `./gradlew run` would work. This pins it.

## Scope
**Config only.** No code, no dependency changes, no behavior change for existing local workflows. CHANGELOG bumped to v0.4.1.

## Generative AI acknowledgment
Per the COMP2850 assessment brief (amber rating for generative AI):

- **Model**: Claude Opus 4.6 (Anthropic), via Claude Code CLI.
- **AI-drafted**: the entire `.devcontainer/devcontainer.json` (image selection, port forwarding, postCreateCommand, recommended VS Code extensions).
- **Human verification**: Charlie Wu validated against the project's `build.gradle.kts` `jvmToolchain(17)` requirement and confirmed the JSON follows the official devcontainer schema.

See PR #4 for the full retroactive log in `AI_USAGE.md`.

## Test plan
- [ ] Open the repo in a fresh Codespace — wait for "postCreateCommand" to finish (first time may take ~1 min)
- [ ] In terminal: `cd "2850final project" && ./gradlew run`
- [ ] App boots, port 8080 auto-forwarded, browser opens to login page
- [ ] Local dev (no Codespace) still works as before — unaffected