### PR TITLE
docs: add AI usage acknowledgment & code comments (v0.4.2)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.4.2] - 2026-04-29 — AI acknowledgment & code comments
+
+### Added
+- `AI_USAGE.md` at the repo root — canonical log of every AI-assisted contribution (model, scope, what the human verified) for COMP2850 amber-rated AI use compliance.
+- Header comments in `static/css/styles.css` and `static/js/app.js` naming the AI model (Claude Opus 4.6) and the lines/sections it drafted, per the assessment brief example format.
+- README "Generative AI usage" section pointing to the log.
+
+### Changed
+- Going forward, no `Co-Authored-By: <AI>` git trailers and no `🤖 Generated with Claude Code` bot footers in PR descriptions — AI acknowledgment lives in code comments and `AI_USAGE.md` instead, treating AI as a supportive tool (not a contributor) in line with the amber rating.
+
+### Notes
+- No code behavior changes — comments and documentation only.
+- Retroactively documents AI assistance for v0.4.0 (UI refresh) and v0.4.1 (devcontainer config).
+
+---
+
 ## [v0.4.1] - 2026-04-29 — Codespace / dev container config
 
 ### Added

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -4,6 +4,16 @@
    Good Food — global styles
    Color tokens use semantic naming and resolve via theme.
    Dark mode: auto via prefers-color-scheme, override via [data-theme] on <html>.
+
+   ---- AI acknowledgment (COMP2850 amber-rated AI use) ----
+   The v0.4.0 visual refresh of this stylesheet (color-token reorganization,
+   dark-mode tokens, animation keyframes, focus-visible states, mobile drawer
+   styles, modal/toast/skeleton components) was drafted with Claude Opus 4.6
+   (Anthropic) acting as a front-end pair-programmer. Charlie Wu reviewed
+   every rule, ran the app locally, tested light/dark + mobile breakpoints in
+   Chrome DevTools, and approved before merge. Component class names and
+   structural CSS pre-dating v0.4.0 were authored by the team.
+   See AI_USAGE.md in the repo root for the full log.
    ============================================================ */
 
 :root {

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -1,3 +1,17 @@
+/*
+ * Good Food — front-end glue (auth tabs, food modal, food search, star rating,
+ * theme toggle, mobile sidebar drawer).
+ *
+ * AI acknowledgment (COMP2850 amber-rated AI use):
+ * The v0.4.0 additions — initTheme() and initSidebarDrawer(), plus the early
+ * synchronous theme application near the bottom of this file (~lines 162–220) —
+ * were drafted with Claude Opus 4.6 (Anthropic) acting as a front-end
+ * pair-programmer. Charlie Wu reviewed every line, tested the toggle and
+ * drawer end-to-end in Chrome DevTools, and approved before merge.
+ * initAuthTabs(), initFoodModal(), initFoodSearch(), and initStarRating()
+ * pre-date v0.4.0 and were authored by the team.
+ * See AI_USAGE.md in the repo root for the full log.
+ */
 (function () {
     "use strict";
 

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,0 +1,57 @@
+# AI Usage Log
+
+This project is COMP2850 Software Engineering — Group Project at the University of Leeds. The assignment is rated **amber** for use of generative AI, meaning AI tools may be used in a *supportive* role and **must be acknowledged**. This document is the canonical record of where and how generative AI assisted this codebase.
+
+> *Reference:* COMP2850 Assessment Brief, Section 7 — "Academic misconduct and plagiarism / Generative AI". The brief explicitly permits AI for: proofreading, spoof test data, summarising the spec, debugging support, concept explanation, and **front-end code support**.
+
+## Contributors using AI
+
+- **Charlie Wu** (`Charlie-920`) — used Claude Opus 4.6 via Claude Code CLI for the contributions logged below. All AI-generated code was reviewed, tested, and merged manually.
+
+## Tool
+
+| Tool | Model | Vendor | Mode of use |
+|---|---|---|---|
+| Claude Code CLI | Claude Opus 4.6 | Anthropic | Pair-programming; AI drafts, human reviews + tests + merges |
+
+## Log of AI-assisted contributions
+
+### v0.4.0 — UI visual refresh, dark mode, component polish (PR #2)
+
+| File | What AI drafted | Human verification |
+|---|---|---|
+| `2850final project/src/main/resources/static/css/styles.css` | Whole-file rewrite (~767 added lines): semantic color tokens, light/dark theme variables, `:focus-visible` rings, animation keyframes (`shimmer`, `bubble-in`, `toast-in`, `skeleton`), card hover lift, modal scale-in + backdrop blur, mobile drawer styles, tablet breakpoint, `prefers-reduced-motion` rule, print stylesheet | Charlie Wu ran `./gradlew run`, navigated every page, tested light/dark toggle, resized to <840 px and <480 px in Chrome DevTools, confirmed no console errors, no layout regressions. |
+| `2850final project/src/main/resources/static/js/app.js` | Added `initTheme()` (theme-toggle handler with localStorage persistence + flash-of-wrong-theme prevention) and `initSidebarDrawer()` (mobile drawer open/close logic) | Charlie Wu tested theme persistence across reloads, drawer open via hamburger, close via backdrop / Escape / nav-link click. |
+| `2850final project/src/main/resources/templates/auth/login.html` | Inserted floating theme-toggle button (3 lines) | Charlie Wu visually verified position and dark-mode contrast. |
+| `2850final project/src/main/resources/templates/{subscriber,professional}/*.html` (10 files) | Inserted hamburger toggle, sidebar backdrop, and theme-toggle button (3 lines added per file via a Python script) | Charlie Wu spot-checked dashboard, diary, recipes, professional dashboard, professional client-detail. |
+
+### v0.4.1 — Codespace devcontainer (PR #3)
+
+| File | What AI drafted | Human verification |
+|---|---|---|
+| `.devcontainer/devcontainer.json` | Whole file: pinned JDK 17 base image, port 8080 forward + auto-open-browser, `postCreateCommand` to warm Gradle, recommended VS Code extensions | Charlie Wu validated against the project's `build.gradle.kts` `jvmToolchain(17)` requirement and confirmed the structure follows the official devcontainer schema. |
+
+### v0.4.2 — AI acknowledgment & code comments (this PR)
+
+| File | What AI drafted | Human verification |
+|---|---|---|
+| Header comments in `styles.css` and `app.js` | Wording of the AI-acknowledgment block | Charlie Wu reviewed the wording and confirmed it accurately describes what AI did and what the human did. |
+| `AI_USAGE.md` (this file) | Initial structure and entries | Charlie Wu reviewed every entry for accuracy. |
+
+## Code/files NOT touched by AI
+
+The entire **backend** (Kotlin, Ktor, Exposed, routes, services, models, seed data, SQL files) was authored by the team. AI's role was strictly front-end polish + dev tooling.
+
+- `src/main/kotlin/com/goodfood/**` — team
+- `src/main/resources/*.sql` — team
+- `src/main/resources/application.conf` — team
+- `build.gradle.kts`, `settings.gradle.kts` — team
+- `Dockerfile`, `ER_diagram.md`, `UI_wireframes.md`, `README.md` — team
+- The pre-v0.4.0 baseline of `styles.css` and `app.js` — team
+
+## Policy going forward
+
+- AI suggestions land in a feature branch, never directly on `main`.
+- Every AI-assisted commit / PR has the model and scope acknowledged in the PR description and (where the change is non-trivial) in a header comment in the file.
+- The committer / author of every commit is the human team member running the tool — never the AI service account. We do not use `Co-Authored-By: <AI>` git trailers because the assignment expects human authorship with AI in a supportive role; the trailer would misrepresent contribution attribution.
+- Updates to this log go in the same PR as the AI-assisted change.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The database is auto-created on startup with seed data (sample users, foods, rec
 
 The original static HTML/CSS prototype is in `ui-prototype/`. Open `ui-prototype/index.html` in a browser to view it.
 
+## Generative AI usage
+
+Per the COMP2850 brief (amber rating for generative AI), AI-assisted contributions are logged in [`AI_USAGE.md`](AI_USAGE.md). All AI-assisted code was reviewed and tested by a human team member before merging into `main`.
+
 ## Team
 
 COMP2850 Group Project — University of Leeds, 2026


### PR DESCRIPTION
## Summary

Retroactively documents the generative-AI assistance behind v0.4.0 (UI refresh) and v0.4.1 (devcontainer), in the form required by the COMP2850 assessment brief (amber rating for AI).

### What this PR adds
- `AI_USAGE.md` at the repo root — canonical log: which file, which model, what was drafted, what the human verified.
- Header comments in `static/css/styles.css` and `static/js/app.js` naming the model (Claude Opus 4.6) and the lines / sections it drafted. Matches the brief's example format (`# used Copilot to explain how to edit background colour (line 17-21)`).
- README "Generative AI usage" section pointing to the log.
- CHANGELOG bumped to **v0.4.2**.

### What this PR does NOT do
- No code behavior changes.
- Backend, routes, services, models, seed data — all untouched.

## Why

Per the brief Section 7:
> *"must acknowledge where generative AI has been used. You should add a comment stating which lines were written primarily by generative AI and which model was used."*

v0.4.0 introduced ~767 lines of AI-drafted CSS and ~79 lines of AI-drafted JS without acknowledgment. v0.4.1 was an AI-drafted devcontainer config without acknowledgment. This PR closes that gap before submission.

## Policy going forward (recorded in `AI_USAGE.md`)

- AI is treated as a supportive tool, not a contributor: no `Co-Authored-By: <AI>` git trailers, no bot signature footers in PR bodies.
- Every AI-assisted change names the model + scope in a code comment and in `AI_USAGE.md` in the same PR.
- AI suggestions land in feature branches, never directly on `main`.
- The human running the tool is the commit author/committer.

## Test plan

- [ ] `AI_USAGE.md` renders on GitHub with the correct table layout
- [ ] README "Generative AI usage" section links to `AI_USAGE.md`
- [ ] `./gradlew run` still boots — comments are pure documentation, no behavior impact
- [ ] No `Co-authored-by` trailer in this commit's message (checked: clean)