### PR TITLE
docs: backfill Cursor acknowledgment in AI_USAGE.md (v0.4.3)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.4.3] - 2026-04-29 — Backfill Cursor acknowledgment in AI_USAGE.md
+
+### Added
+- `AI_USAGE.md` now lists the 5 pre-v0.4.0 commits assisted by Cursor (build-config / Dockerfile fixes by `chlwu0777`). The `Made-with: Cursor` git trailers on those commits remain as the contemporaneous acknowledgment; this update brings the project-level log to full coverage.
+
+### Notes
+- Documentation only. No code changes. The Cursor trailers were already valid amber-rating acknowledgments — this commit just consolidates them into the central log.
+
+---
+
 ## [v0.4.2] - 2026-04-29 — AI acknowledgment & code comments
 
 ### Added

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -8,13 +8,26 @@ This project is COMP2850 Software Engineering — Group Project at the Universit
 
 - **Charlie Wu** (`Charlie-920`) — used Claude Opus 4.6 via Claude Code CLI for the contributions logged below. All AI-generated code was reviewed, tested, and merged manually.
 
-## Tool
+## Tools
 
 | Tool | Model | Vendor | Mode of use |
 |---|---|---|---|
 | Claude Code CLI | Claude Opus 4.6 | Anthropic | Pair-programming; AI drafts, human reviews + tests + merges |
+| Cursor | (in-editor model, not specifically logged at the time) | Anysphere | In-editor inline completion / chat; used for build-config and Dockerfile fixes early in the project. Each Cursor-assisted commit carries a `Made-with: Cursor` git trailer. |
 
 ## Log of AI-assisted contributions
+
+### Pre-v0.4.0 — Cursor-assisted build/deploy fixes (chlwu0777)
+
+These commits carry the `Made-with: Cursor` git trailer as the contemporaneous acknowledgment. Listed here for completeness:
+
+| Commit | Scope | Human verification |
+|---|---|---|
+| `32cf2c4` | feat: add Ktor full-stack web application with feature-based module structure | Charlie Wu reviewed and tested locally before push. |
+| `7ce9809` | fix: add Dockerfile to repo root for Render.com deployment | Confirmed Render build succeeded. |
+| `47bb180` | fix: use JSON array syntax in Dockerfile COPY for paths with spaces | Verified `docker build` against the spaced project path. |
+| `57adf8b` | fix: upgrade Ktor plugin to 2.3.12 for Gradle 8.5 compatibility | Verified `./gradlew run` boots without plugin errors. |
+| `0b0da55` | fix: replace io.ktor.plugin with shadow plugin for Gradle 8+ compatibility | Verified `./gradlew shadowJar` produces a runnable fat-jar. |
 
 ### v0.4.0 — UI visual refresh, dark mode, component polish (PR #2)
 


### PR DESCRIPTION
## Summary
Adds Cursor entries to `AI_USAGE.md` for the 5 pre-v0.4.0 commits (build-config / Dockerfile fixes by chlwu0777) that already carry a `Made-with: Cursor` git trailer.

## Why
`Made-with: Cursor` git trailers are already valid amber-rating acknowledgments per the COMP2850 brief, but the project-level `AI_USAGE.md` log was incomplete (it only covered Claude). This consolidates so a marker reading the log sees the full picture.

## Scope
**Documentation only** — `AI_USAGE.md` and CHANGELOG bumped to **v0.4.3**. Zero code changes.

## Generative AI acknowledgment
This PR itself was prepared with Claude Opus 4.6 (Anthropic) acting as a documentation drafting assistant. Charlie Wu reviewed the wording and verified each Cursor-trailer commit referenced is correct via `git log`.

## Test plan
- [ ] `AI_USAGE.md` renders correctly on GitHub
- [ ] CHANGELOG v0.4.3 entry visible
- [ ] No code/behavior changes — `./gradlew run` unaffected