### PR TITLE
fix(security): close 4 P0 issues — IDOR x2, cookie flags, LIKE wildcards (v0.4.4)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.4.4] - 2026-04-30 — Critical security fixes
+
+### Fixed
+- **IDOR on professional client view** (#16) — `GET /pro/client/{id}` previously returned any subscriber's diary, goals, and nutrition summary as long as the requester's session role was `professional`. Now also requires an active row in `client_relationships` between the professional and the requested subscriber; otherwise the request is redirected to `/pro/dashboard`.
+- **IDOR on professional advice endpoint** (#17) — `POST /pro/client/{id}/advice` previously created a message addressed to any user id. Same authorisation gate now applies; an extra role check was added on this route for parity with the GET. Submissions to non-client ids now redirect and create no message.
+- **Session cookie missing `HttpOnly` / `SameSite`** (#18) — `config/Security.kt` now sets `cookie.httpOnly = true` and `cookie.extensions["SameSite"] = "Lax"`. JavaScript can no longer read the session cookie, and browsers will not send it on cross-site POST submissions, blocking the standard form-based CSRF path. `Secure` is intentionally left off so `./gradlew run` over plain HTTP in dev / Codespaces keeps working; flip it on for production HTTPS.
+- **`LIKE` wildcard injection in food / recipe search** (#19) — `searchFood()` (DiaryService) and `searchRecipes()` (RecipeService) now escape the SQL wildcards `%` and `_` and the escape character `\` before substituting user input into the `LIKE` pattern. Submitting `%` no longer matches the entire table.
+
+### Notes
+- All four fixes are scoped to authorisation / cookie / search-input handling; no schema changes, no UI changes, no new dependencies.
+- Existing unit tests still pass; manual regression covered the happy paths (Sarah → Alice diary visible, food search for `apple`, recipe search for `salmon`).
+
+---
+
 ## [v0.4.3] - 2026-04-29 — Backfill Cursor acknowledgment in AI_USAGE.md
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/config/Security.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Security.kt
@@ -13,11 +13,27 @@ data class UserSession(
         get() = fullName.split(" ").filter { it.isNotEmpty() }.map { it.first().uppercase() }.joinToString("")
 }
 
+/**
+ * Configure session cookies for authenticated users.
+ *
+ * Defence-in-depth on the cookie itself (closes issue #18):
+ *  - httpOnly = true   — JavaScript can no longer read the cookie, so an XSS bug
+ *                        alone is not enough to steal a session.
+ *  - SameSite = Lax    — browsers will not send the cookie on cross-site POST
+ *                        submissions, blocking the standard form-based CSRF path.
+ *                        Lax (not Strict) keeps top-level GET navigations from
+ *                        external links working as expected.
+ *  - Secure is intentionally NOT forced here so `./gradlew run` over plain HTTP
+ *    in dev / Codespaces keeps working. For a production deployment behind TLS,
+ *    flip `cookie.secure = true` (or gate it on an env flag).
+ */
 fun Application.configureSecurity() {
     install(Sessions) {
         cookie<UserSession>("user_session") {
             cookie.path = "/"
             cookie.maxAgeInSeconds = 86400
+            cookie.httpOnly = true
+            cookie.extensions["SameSite"] = "Lax"
         }
     }
 }

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
@@ -54,8 +54,19 @@ object DiaryService {
         FoodDiaryEntries.deleteWhere { (FoodDiaryEntries.id eq entryId) and (FoodDiaryEntries.userId eq userId) }
     }
 
+    /**
+     * Escape the SQL `LIKE` wildcard characters (`%`, `_`) and the escape char itself
+     * so a user-supplied search term is treated as a literal substring rather than a
+     * pattern. Closes issue #19 for the food-search call site below. The escape
+     * character is the default `\\`, which Exposed maps to the underlying H2 / MySQL
+     * `LIKE ... ESCAPE '\\'` semantics.
+     */
+    private fun escapeLikePattern(input: String): String =
+        input.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     fun searchFood(query: String): List<Map<String, Any>> = transaction {
-        FoodItems.selectAll().where { FoodItems.name.lowerCase() like "%${query.lowercase()}%" }.limit(20).map { row ->
+        val safe = escapeLikePattern(query.lowercase())
+        FoodItems.selectAll().where { FoodItems.name.lowerCase() like "%$safe%" }.limit(20).map { row ->
             mapOf("id" to row[FoodItems.id], "name" to row[FoodItems.name], "category" to row[FoodItems.category], "calories" to row[FoodItems.caloriesPer100g])
         }
     }

--- a/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
@@ -19,6 +19,19 @@ import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+/**
+ * Returns true when [professionalId] currently supervises [subscriberId] via an
+ * active row in [ClientRelationships]. Used to gate the `/pro/client/{id}` routes
+ * so a professional can only access their assigned clients (issues #16, #17).
+ */
+private fun hasActiveRelationship(professionalId: Int, subscriberId: Int): Boolean = transaction {
+    ClientRelationships.selectAll().where {
+        (ClientRelationships.professionalId eq professionalId) and
+            (ClientRelationships.subscriberId eq subscriberId) and
+            (ClientRelationships.status eq "active")
+    }.limit(1).any()
+}
+
 fun Route.professionalRoutes() {
     get("/pro/dashboard") {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
@@ -48,6 +61,9 @@ fun Route.professionalRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         if (session.role != "professional") return@get call.respondRedirect("/dashboard")
         val clientId = call.parameters["id"]?.toIntOrNull() ?: return@get call.respondRedirect("/pro/dashboard")
+        // Authorisation gate: only show this client's data if the professional currently
+        // supervises them. Closes #16 (IDOR — any client visible to any professional).
+        if (!hasActiveRelationship(session.userId, clientId)) return@get call.respondRedirect("/pro/dashboard")
         val dateStr = call.request.queryParameters["date"]
         val date = if (dateStr != null) LocalDate.parse(dateStr) else LocalDate.now()
         val unread = MessageService.getUnreadCount(session.userId)
@@ -69,7 +85,11 @@ fun Route.professionalRoutes() {
 
     post("/pro/client/{id}/advice") {
         val session = call.sessions.get<UserSession>() ?: return@post call.respondRedirect("/login")
+        if (session.role != "professional") return@post call.respondRedirect("/dashboard")
         val clientId = call.parameters["id"]?.toIntOrNull() ?: return@post call.respondRedirect("/pro/dashboard")
+        // Authorisation gate: only let a professional message a current client of theirs.
+        // Closes #17 (IDOR — any user could be messaged via the advice endpoint).
+        if (!hasActiveRelationship(session.userId, clientId)) return@post call.respondRedirect("/pro/dashboard")
         val message = call.receiveParameters()["message"] ?: ""
         if (message.isNotBlank()) MessageService.sendMessage(session.userId, clientId, message)
         call.respondRedirect("/pro/client/$clientId")

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -11,10 +11,21 @@ import java.time.LocalDateTime
 
 object RecipeService {
 
+    /**
+     * Escape SQL `LIKE` wildcards (`%`, `_`) and the escape character itself so a
+     * user-supplied search term is matched as a literal substring. Closes issue #19
+     * for the recipe-title search call site below.
+     */
+    private fun escapeLikePattern(input: String): String =
+        input.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     fun searchRecipes(query: String?, difficulty: String?): List<Map<String, Any?>> = transaction {
         val baseQuery = Recipes.selectAll()
         val filtered = baseQuery.let { q ->
-            if (!query.isNullOrBlank()) q.andWhere { Recipes.title.lowerCase() like "%${query.lowercase()}%" }
+            if (!query.isNullOrBlank()) {
+                val safe = escapeLikePattern(query.lowercase())
+                q.andWhere { Recipes.title.lowerCase() like "%$safe%" }
+            }
             if (!difficulty.isNullOrBlank() && difficulty != "all") q.andWhere { Recipes.difficulty eq difficulty }
             q
         }

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -51,6 +51,14 @@ These commits carry the `Made-with: Cursor` git trailer as the contemporaneous a
 | Header comments in `styles.css` and `app.js` | Wording of the AI-acknowledgment block | Charlie Wu reviewed the wording and confirmed it accurately describes what AI did and what the human did. |
 | `AI_USAGE.md` (this file) | Initial structure and entries | Charlie Wu reviewed every entry for accuracy. |
 
+### v0.4.4 — Critical security fixes (closes #16, #17, #18, #19)
+
+| File | What AI drafted | Human verification |
+|---|---|---|
+| `professional/ProfessionalRoutes.kt` — new `hasActiveRelationship()` helper + two authorisation gates on `GET /pro/client/{id}` and `POST /pro/client/{id}/advice` | Helper structure and the gate pattern (`return@get respondRedirect` on missing relationship) drafted with Claude Opus 4.6 acting as a Kotlin pair-programmer. | Charlie Wu reproduced the original IDOR with seeded users (Sarah supervises only Alice), confirmed `/pro/client/2` redirects to dashboard after the fix, confirmed `/pro/client/1` (the legitimate client) still works, posted advice to a non-client and verified no message row is created. |
+| `config/Security.kt` — `cookie.httpOnly = true` and `cookie.extensions["SameSite"] = "Lax"` plus a comment block explaining why `Secure` is left off in dev | Wording of the comment block; the two cookie property lines are standard Ktor API and were verified against the Ktor 2.3.7 docs. | Charlie Wu logged in via Chrome DevTools → Application → Cookies, confirmed the `user_session` cookie now shows `HttpOnly ✓` and `SameSite Lax`. |
+| `diary/DiaryService.kt` and `recipes/RecipeService.kt` — private `escapeLikePattern()` helpers escaping `\`, `%`, `_`, applied to the `LIKE` clauses in `searchFood()` and `searchRecipes()` | The escape helper and its three-step `replace()` chain. | Charlie Wu searched for `%` in food search → returned 0 rows (was previously the entire 50+ table); searched `apple` → still returns the apple food items as expected; same checks against recipe search. |
+
 ## Code/files NOT touched by AI
 
 The entire **backend** (Kotlin, Ktor, Exposed, routes, services, models, seed data, SQL files) was authored by the team. AI's role was strictly front-end polish + dev tooling.


### PR DESCRIPTION
## Summary

Closes the four critical security gaps tracked in #16, #17, #18, #19. All four fixes are localised to existing files and require no schema or dependency changes.

| # | Bug | Fix |
|---|---|---|
| #16 | IDOR — any professional could view any subscriber's diary via `GET /pro/client/{id}` | New `hasActiveRelationship(professionalId, subscriberId)` helper queries `client_relationships` for an active row; route redirects to `/pro/dashboard` when missing. |
| #17 | IDOR — any professional could send `POST /pro/client/{id}/advice` to any user | Same helper applied; an explicit role check was added on this route for parity with the GET. |
| #18 | Session cookie missing `HttpOnly` / `SameSite` | `config/Security.kt` now sets `cookie.httpOnly = true` and `cookie.extensions["SameSite"] = "Lax"`. `Secure` is intentionally left off so dev / HTTP / Codespaces keeps working; the comment block explains how to flip it for production TLS. |
| #19 | `LIKE` wildcard injection in `searchFood()` and `searchRecipes()` | Private `escapeLikePattern()` helper escapes `\\`, `%`, `_` before they reach the `LIKE` clause. |

## Why now

These are the P0 items called out in the security audit logged earlier this week. They directly affect the **Functionality [20]** rubric line on *"good consideration of security and validation"*, and the demo on 11 May will benefit from being able to talk through real fixes (defence-in-depth on the cookie, ownership-check on the IDORs, wildcard escaping on the search).

## Generative AI acknowledgment

Per the COMP2850 brief (amber-rated AI use):

- **Model**: Claude Opus 4.6 (Anthropic), via Claude Code CLI, in pair-programming mode.
- **AI-drafted**: the `hasActiveRelationship()` helper structure, the gate-and-redirect pattern reused on both pro routes, the wording of the comment blocks in `Security.kt` and the two service files, and the three-step `replace()` chain in `escapeLikePattern()`. All four fixes amount to ~30 lines of net new code.
- **Human verification (Charlie Wu)**:
  - Reproduced the IDOR with seeded users (Sarah supervises Alice only) → confirmed `/pro/client/2` (Bob) redirects after the fix; `/pro/client/1` (Alice, the legitimate client) still works.
  - Posted advice to a non-client id → confirmed no message row created.
  - Logged in via Chrome DevTools → Application → Cookies → confirmed `user_session` now shows `HttpOnly ✓` and `SameSite Lax`.
  - Searched for `%` in food and recipe search → 0 rows (was previously the whole table); searched for `apple` and `salmon` → still return expected items.
  - Existing 13 unit tests still pass (`./gradlew test`).
- **Not AI-touched**: the `ClientRelationships` table and the existing service-layer queries were authored by the team.

Full retroactive log in [`AI_USAGE.md`](../blob/main/AI_USAGE.md). CHANGELOG bumped to v0.4.4.

## Test plan

- [ ] `./gradlew test` — all 13 existing unit tests pass
- [ ] `./gradlew run`, log in as Sarah (`sarah@clinic.com` / `password`)
  - [ ] `/pro/client/1` (Alice) renders her diary as before
  - [ ] `/pro/client/2` (Bob) redirects to `/pro/dashboard`
  - [ ] Posting advice to Bob's id (curl or DevTools) creates no message row in DB
- [ ] DevTools → Application → Cookies → `user_session` shows `HttpOnly` ✓ and `SameSite=Lax`
- [ ] Diary food search for `%` returns 0 / very few rows; for `apple` returns the apple food item; for `chicken` returns chicken
- [ ] Recipe search for `%` returns 0 / very few rows; for `salmon` returns the salmon recipe