### PR TITLE
ux: food-search hint + threshold 2->3 (v0.5.1)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.5.1] - 2026-05-01 — Food-search hint & threshold (closes #38)
+
+### Changed
+- The diary "Add food" search input now shows an inline hint underneath: *"Type at least 3 letters to search. Try ban, chi, or oat."* The placeholder also says *"Type at least 3 letters…"* instead of the vague *"Type to search…"*.
+- The JS minimum-query-length constant is bumped from 2 → 3 so the actual behaviour matches the hint exactly (extracted as `MIN_QUERY_LEN` so the next change is a one-liner).
+- `aria-describedby` wires the hint into the input's accessibility tree so screen-reader users hear the threshold too.
+
+### Why
+Testers (and one of our own teammates) kept typing 1–2 letters into the search and giving up when nothing appeared — the field looked broken on first interaction. The hint is the smallest possible fix.
+
+---
+
 ## [v0.5.0] - 2026-05-01 — Visual identity refresh inspired by Anthropic
 
 We've spent the last few weeks looking at how research-led companies communicate visually, and Anthropic's site (anthropic.com) kept coming up as a reference the team admired — the warm parchment ivory background instead of clinical white, the strict alternation of light and slate-dark surfaces, the serif-plus-grotesque type pairing that reads more "research journal" than "startup", and the discipline of holding the entire chromatic budget for a single terracotta accent. As a learning exercise we studied their public design tokens and component vocabulary, then translated the system onto the existing Good Food class names so we could see what our app looked like in that visual idiom without rewriting any templates.

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -90,11 +90,16 @@
         var submitBtn = document.getElementById("modal-submit");
         if (!input || !results) return;
 
+        // Minimum query length: 3 — matches the inline hint shown next to the
+        // search input in subscriber/diary.html. Bumping this here without also
+        // updating that hint would re-introduce the original UX problem
+        // (testers typing 1-2 chars and seeing nothing happen — issue #38).
+        var MIN_QUERY_LEN = 3;
         var t = null;
         input.addEventListener("input", function () {
             clearTimeout(t);
             var q = input.value.trim();
-            if (q.length < 2) {
+            if (q.length < MIN_QUERY_LEN) {
                 results.innerHTML = "";
                 results.classList.remove("is-visible");
                 return;

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -92,7 +92,10 @@
 
             <label class="field">
                 <span class="field__label">Search foods</span>
-                <input type="search" id="food-search-input" class="js-food-search" placeholder="Type to search…" autocomplete="off"/>
+                <input type="search" id="food-search-input" class="js-food-search"
+                       placeholder="Type at least 3 letters…" autocomplete="off"
+                       aria-describedby="food-search-hint"/>
+                <p id="food-search-hint" class="field-hint">Type at least 3 letters to search. Try <em>ban</em>, <em>chi</em>, or <em>oat</em>.</p>
             </label>
             <div id="food-search-results" class="food-search-results" role="listbox"></div>
 

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -51,6 +51,13 @@ These commits carry the `Made-with: Cursor` git trailer as the contemporaneous a
 | Header comments in `styles.css` and `app.js` | Wording of the AI-acknowledgment block | Charlie Wu reviewed the wording and confirmed it accurately describes what AI did and what the human did. |
 | `AI_USAGE.md` (this file) | Initial structure and entries | Charlie Wu reviewed every entry for accuracy. |
 
+### v0.5.1 — Food-search hint and threshold (closes #38)
+
+| File | What AI drafted | Human verification |
+|---|---|---|
+| `src/main/resources/templates/subscriber/diary.html` | The wording of the inline hint (`"Type at least 3 letters to search. Try ban, chi, or oat."`) and the `aria-describedby` wiring. | Charlie Wu read the seeded food list and chose the example terms (`ban`, `chi`, `oat`) so the hint examples actually return results. |
+| `src/main/resources/static/js/app.js` | Pulling the magic number `2` out into a named `MIN_QUERY_LEN = 3` constant, plus the comment linking the threshold back to the hint in the template. | Charlie Wu confirmed the new threshold matches the hint exactly. |
+
 ### v0.5.0 — Anthropic-inspired visual identity refresh (closes #36)
 
 | File | What AI drafted | Human verification |


### PR DESCRIPTION
## Summary
Closes #38. Adds a "Type at least 3 letters to search. Try ban, chi, or oat." hint under the diary food-search input, updates the placeholder, wires `aria-describedby` so screen readers pick it up, and bumps the JS threshold from 2 → 3 so behaviour matches the hint exactly.

## Generative AI acknowledgment
- **Model**: Claude Opus 4.6 (Anthropic).
- **AI-drafted**: hint wording, the `MIN_QUERY_LEN` named-constant refactor, and the linking comment.
- **Human (Charlie Wu)**: chose the example search terms (`ban`/`chi`/`oat`) against the actual seeded food list, verified the modal still works.

## Test plan
- [ ] CI green
- [ ] Open `/diary` → "Add food" modal → input shows new placeholder + hint
- [ ] Typing 1–2 letters does nothing (intentional)
- [ ] Typing `ban` returns Banana