### PR TITLE
feat: persist accounts on render via postgres (v0.6.2)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.2] - 2026-05-01 — Persist accounts on Render via PostgreSQL (closes #44)
+
+### Why
+The H2 database file (`./data/goodfood.mv.db`) lives inside each container's local filesystem and is `.gitignore`d, so it never travels with the code. On Render's free tier the container is rebuilt on every deploy and on idle spin-up, which wipes `data/` and erases every account a user registered through the web UI. The seed accounts only appear permanent because `SeedData.insertIfEmpty()` re-runs against the fresh schema and re-creates them. The same dynamic explains why a Codespace registered account disappears the next time the codespace is recycled. For the assessment demo the marker needs to register an account and have it survive a redeploy, so production needs a database that lives outside the container.
+
+### Changed
+- **`Database.kt`** — new `resolveDbSettings()` helper. When the `DATABASE_URL` environment variable is present (Render injects this when a PostgreSQL service is linked to the web service) the libpq form `postgres://user:pass@host:port/db[?…]` is parsed into a JDBC URL plus separate credentials, and the connection goes through `org.postgresql.Driver`. When the variable is unset — Codespaces, local dev, CI — the existing H2 file path from `application.conf` is used unchanged. Any query string on the original URL (e.g. `sslmode=require` for an external Render endpoint) is preserved verbatim.
+- **`build.gradle.kts`** — added `org.postgresql:postgresql:42.7.4` alongside the existing H2 driver. Both ship in the fat jar so the same artifact runs locally on H2 and on Render against PostgreSQL.
+
+### Notes
+- Existing Exposed queries are dialect-portable (`Recipes.title.lowerCase() like ?`, `FoodItems.name.lowerCase() like ?`); `lowerCase()` compiles to `LOWER(col)` which works on H2, MySQL, and PostgreSQL alike. Schema generation is delegated to `SchemaUtils.create(...)` and Exposed picks the right DDL per dialect.
+- Render setup after merge: provision a PostgreSQL Free instance, attach it to the web service so `DATABASE_URL` is auto-injected, then redeploy. No code switch needed — the env var alone flips the runtime to PostgreSQL.
+
+---
+
 ## [v0.6.1] - 2026-05-01 — Fix Render build (Gradle 8.5)
 
 ### Fixed

--- a/2850final project/build.gradle.kts
+++ b/2850final project/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
 
     implementation("com.h2database:h2:$h2Version")
+    implementation("org.postgresql:postgresql:42.7.4")
     implementation("at.favre.lib:bcrypt:0.10.2")
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
 

--- a/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
@@ -11,13 +11,43 @@ import io.ktor.server.application.*
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
+import java.net.URI
+
+private data class DbSettings(val driver: String, val url: String, val user: String, val password: String)
+
+/**
+ * When `DATABASE_URL` is set (Render injects this when a PostgreSQL service is
+ * linked) we connect to PostgreSQL so user accounts survive container rebuilds.
+ * Otherwise we fall back to the H2 file from `application.conf` — convenient
+ * for Codespaces / local dev where data living in `./data/` is good enough.
+ *
+ * Render hands us the libpq form `postgres://user:pass@host:port/db`, but JDBC
+ * needs `jdbc:postgresql://host:port/db` with credentials passed separately,
+ * so the URL is parsed before being handed to `Database.connect`.
+ */
+private fun Application.resolveDbSettings(): DbSettings {
+    val raw = System.getenv("DATABASE_URL")?.trim().orEmpty()
+    if (raw.startsWith("postgres://") || raw.startsWith("postgresql://")) {
+        val uri = URI(raw)
+        val (pgUser, pgPassword) = uri.userInfo.orEmpty().split(":", limit = 2).let {
+            (it.getOrNull(0).orEmpty()) to (it.getOrNull(1).orEmpty())
+        }
+        val port = if (uri.port == -1) 5432 else uri.port
+        val query = uri.rawQuery?.let { "?$it" } ?: ""
+        val jdbcUrl = "jdbc:postgresql://${uri.host}:$port${uri.path}$query"
+        return DbSettings("org.postgresql.Driver", jdbcUrl, pgUser, pgPassword)
+    }
+    val cfg = environment.config
+    return DbSettings(
+        cfg.property("database.driver").getString(),
+        cfg.property("database.url").getString(),
+        cfg.property("database.user").getString(),
+        cfg.property("database.password").getString()
+    )
+}
 
 fun Application.configureDatabase() {
-    val config = environment.config
-    val driver = config.property("database.driver").getString()
-    val url = config.property("database.url").getString()
-    val user = config.property("database.user").getString()
-    val password = config.property("database.password").getString()
+    val (driver, url, user, password) = resolveDbSettings()
 
     Database.connect(url, driver, user, password)
 


### PR DESCRIPTION
## Summary
- H2 lives inside the container filesystem and Render free-tier containers are rebuilt on every deploy / idle spin-up, so any account a user registered through the web UI is wiped on the next push. Seed accounts only look permanent because `SeedData.insertIfEmpty()` re-runs against the fresh schema. Same root cause for accounts disappearing across recycled Codespaces.
- Hand the production runtime a database that lives outside the container: when `DATABASE_URL` is present (Render injects this when a postgres service is linked to the web service), parse the libpq form `postgres://user:pass@host:port/db[?…]` into a `jdbc:postgresql://…` URL + credentials and connect through `org.postgresql.Driver`. When the env var is unset — Codespaces, local dev, CI — fall back to the existing H2 file from `application.conf`. Same fat jar runs on both.
- Search queries (`Recipes.title.lowerCase() like ?`, `FoodItems.name.lowerCase() like ?`) compile to `LOWER(col) LIKE ?` which is portable across H2 / MySQL / PostgreSQL, and Exposed picks dialect-correct DDL on `SchemaUtils.create(...)`, so no query rewrites were needed.

## Files
- `2850final project/src/main/kotlin/com/goodfood/config/Database.kt` — new `resolveDbSettings()` helper that picks the runtime DB based on `DATABASE_URL`.
- `2850final project/build.gradle.kts` — adds `org.postgresql:postgresql:42.7.4` next to the existing H2 driver.
- `2850final project/CHANGELOG.md` — v0.6.2 entry.

## Test plan
- [ ] CI green on the PR (build + tests against H2 — `DATABASE_URL` is unset, so the H2 fallback path is exercised)
- [ ] After merge: provision a free PostgreSQL instance on Render, link it to the web service, verify a freshly-registered account survives a redeploy
- [ ] Local dev / Codespaces still work unchanged (no `DATABASE_URL` → H2)

Closes #44