### PR TITLE
fix: ui detail bugs (v0.6.3)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.3] - 2026-05-01 — UI detail bug fixes (closes #46)
+
+### Fixed
+- Trailing `.00` on numeric values across Dashboard / Diary / Goals / professional client-detail.
+- Raw ISO timestamps on Messages chat bubbles.
+- Bare text-only Recipe cards.
+
+---
+
 ## [v0.6.2] - 2026-05-01 — Persist accounts on Render via PostgreSQL (closes #44)
 
 ### Why

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
@@ -4,6 +4,7 @@ import com.goodfood.config.UserSession
 import com.goodfood.config.model
 import com.goodfood.goals.GoalService
 import com.goodfood.messages.MessageService
+import com.goodfood.util.fmt
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -23,21 +24,46 @@ fun Route.dashboardRoutes() {
         val goals = GoalService.getGoals(session.userId)
         val unread = MessageService.getUnreadCount(session.userId)
         val meals = listOf("breakfast", "lunch", "snack", "dinner").map { meal ->
-            val me = entries.filter { it["mealType"] == meal }; mapOf("type" to meal, "entries" to me, "calories" to me.sumOf { it["calories"] as BigDecimal })
+            val me = entries.filter { it["mealType"] == meal }
+            val mealCalories = me.sumOf { it["calories"] as BigDecimal }
+            mapOf(
+                "type" to meal,
+                "entries" to me.map { e -> mapOf(
+                    "id" to e["id"],
+                    "foodName" to e["foodName"],
+                    "mealType" to e["mealType"],
+                    "quantity" to (e["quantity"] as BigDecimal).fmt(1),
+                    "calories" to (e["calories"] as BigDecimal).fmt(0),
+                    "protein" to (e["protein"] as BigDecimal).fmt(1),
+                    "carbs" to (e["carbs"] as BigDecimal).fmt(1),
+                    "fat" to (e["fat"] as BigDecimal).fmt(1),
+                    "notes" to e["notes"]
+                ) },
+                "calories" to mealCalories.fmt(0)
+            )
         }
         fun pct(current: BigDecimal, goal: BigDecimal?): Int {
             if (goal == null || goal == BigDecimal.ZERO) return 0
             return current.multiply(BigDecimal(100)).divide(goal, 0, RoundingMode.HALF_UP).toInt().coerceAtMost(100)
         }
+        val goalCal = goals?.get("calories") ?: BigDecimal("2000")
+        val goalProt = goals?.get("protein") ?: BigDecimal("80")
+        val goalCarb = goals?.get("carbs") ?: BigDecimal("250")
+        val goalFat = goals?.get("fat") ?: BigDecimal("65")
         call.respond(ThymeleafContent("subscriber/dashboard", model(
             "session" to session, "date" to today.format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy")), "meals" to meals,
-            "totalCalories" to summary["calories"], "totalProtein" to summary["protein"], "totalCarbs" to summary["carbs"], "totalFat" to summary["fat"],
-            "goalCalories" to (goals?.get("calories") ?: BigDecimal("2000")), "goalProtein" to (goals?.get("protein") ?: BigDecimal("80")),
-            "goalCarbs" to (goals?.get("carbs") ?: BigDecimal("250")), "goalFat" to (goals?.get("fat") ?: BigDecimal("65")),
-            "pctCalories" to pct(summary["calories"]!!, goals?.get("calories") ?: BigDecimal("2000")),
-            "pctProtein" to pct(summary["protein"]!!, goals?.get("protein") ?: BigDecimal("80")),
-            "pctCarbs" to pct(summary["carbs"]!!, goals?.get("carbs") ?: BigDecimal("250")),
-            "pctFat" to pct(summary["fat"]!!, goals?.get("fat") ?: BigDecimal("65")),
+            "totalCalories" to (summary["calories"] ?: BigDecimal.ZERO).fmt(0),
+            "totalProtein" to (summary["protein"] ?: BigDecimal.ZERO).fmt(1),
+            "totalCarbs" to (summary["carbs"] ?: BigDecimal.ZERO).fmt(1),
+            "totalFat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1),
+            "goalCalories" to goalCal.fmt(0),
+            "goalProtein" to goalProt.fmt(1),
+            "goalCarbs" to goalCarb.fmt(1),
+            "goalFat" to goalFat.fmt(1),
+            "pctCalories" to pct(summary["calories"]!!, goalCal),
+            "pctProtein" to pct(summary["protein"]!!, goalProt),
+            "pctCarbs" to pct(summary["carbs"]!!, goalCarb),
+            "pctFat" to pct(summary["fat"]!!, goalFat),
             "unreadMessages" to unread, "activePage" to "dashboard")))
     }
 }

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DiaryRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DiaryRoutes.kt
@@ -4,6 +4,7 @@ import com.goodfood.config.UserSession
 import com.goodfood.config.model
 import com.goodfood.goals.GoalService
 import com.goodfood.messages.MessageService
+import com.goodfood.util.fmt
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
@@ -24,12 +25,35 @@ fun Route.diaryRoutes() {
         val goals = GoalService.getGoals(session.userId)
         val unread = MessageService.getUnreadCount(session.userId)
         val meals = listOf("breakfast", "lunch", "snack", "dinner").map { meal ->
-            val me = entries.filter { it["mealType"] == meal }; mapOf("type" to meal, "entries" to me, "calories" to me.sumOf { it["calories"] as BigDecimal })
+            val me = entries.filter { it["mealType"] == meal }
+            val mealCalories = me.sumOf { it["calories"] as BigDecimal }
+            mapOf(
+                "type" to meal,
+                "entries" to me.map { e -> mapOf(
+                    "id" to e["id"],
+                    "foodName" to e["foodName"],
+                    "mealType" to e["mealType"],
+                    "quantity" to (e["quantity"] as BigDecimal).fmt(1),
+                    "calories" to (e["calories"] as BigDecimal).fmt(0),
+                    "protein" to (e["protein"] as BigDecimal).fmt(1),
+                    "carbs" to (e["carbs"] as BigDecimal).fmt(1),
+                    "fat" to (e["fat"] as BigDecimal).fmt(1),
+                    "notes" to e["notes"]
+                ) },
+                "calories" to mealCalories.fmt(0)
+            )
         }
+        val displaySummary = mapOf(
+            "calories" to (summary["calories"] ?: BigDecimal.ZERO).fmt(0),
+            "protein" to (summary["protein"] ?: BigDecimal.ZERO).fmt(1),
+            "carbs" to (summary["carbs"] ?: BigDecimal.ZERO).fmt(1),
+            "fat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1)
+        )
+        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
         call.respond(ThymeleafContent("subscriber/diary", model(
             "session" to session, "date" to date, "dateFormatted" to date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")),
-            "prevDate" to date.minusDays(1), "nextDate" to date.plusDays(1), "meals" to meals, "summary" to summary,
-            "goals" to (goals ?: emptyMap()), "unreadMessages" to unread, "activePage" to "diary")))
+            "prevDate" to date.minusDays(1), "nextDate" to date.plusDays(1), "meals" to meals, "summary" to displaySummary,
+            "goals" to displayGoals, "unreadMessages" to unread, "activePage" to "diary")))
     }
 
     post("/diary/add") {

--- a/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
@@ -4,12 +4,14 @@ import com.goodfood.config.UserSession
 import com.goodfood.config.model
 import com.goodfood.diary.DiaryService
 import com.goodfood.messages.MessageService
+import com.goodfood.util.fmt
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.thymeleaf.*
+import java.math.BigDecimal
 
 fun Route.goalRoutes() {
     get("/goals") {
@@ -17,8 +19,14 @@ fun Route.goalRoutes() {
         val goals = GoalService.getGoals(session.userId)
         val weekly = DiaryService.getWeeklySummary(session.userId)
         val unread = MessageService.getUnreadCount(session.userId)
+        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
+        val displayWeekly = weekly.map { w -> mapOf(
+            "date" to w["date"],
+            "dayName" to w["dayName"],
+            "calories" to (w["calories"] as BigDecimal).fmt(0)
+        ) }
         call.respond(ThymeleafContent("subscriber/goals", model(
-            "session" to session, "goals" to (goals ?: emptyMap()), "weekly" to weekly, "unreadMessages" to unread, "activePage" to "goals")))
+            "session" to session, "goals" to displayGoals, "weekly" to displayWeekly, "unreadMessages" to unread, "activePage" to "goals")))
     }
 
     post("/goals") {

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
@@ -1,6 +1,7 @@
 package com.goodfood.messages
 
 import com.goodfood.auth.Users
+import com.goodfood.util.fmtChatTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
@@ -60,7 +61,9 @@ object MessageService {
             ((AdviceMessages.senderId eq partnerId) and (AdviceMessages.receiverId eq userId))
         }.orderBy(AdviceMessages.sentAt).map { row ->
             mapOf("id" to row[AdviceMessages.id], "senderId" to row[AdviceMessages.senderId],
-                "message" to row[AdviceMessages.message], "sentAt" to row[AdviceMessages.sentAt], "isMine" to (row[AdviceMessages.senderId] == userId))
+                "message" to row[AdviceMessages.message],
+                "sentAt" to row[AdviceMessages.sentAt].fmtChatTime(),
+                "isMine" to (row[AdviceMessages.senderId] == userId))
         }
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
@@ -6,6 +6,7 @@ import com.goodfood.config.model
 import com.goodfood.diary.DiaryService
 import com.goodfood.goals.GoalService
 import com.goodfood.messages.MessageService
+import com.goodfood.util.fmt
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
@@ -48,7 +49,7 @@ fun Route.professionalRoutes() {
                     val pct = if (goalCal > BigDecimal.ZERO) summary["calories"]!!.multiply(BigDecimal(100)).divide(goalCal, 0, RoundingMode.HALF_UP).toInt() else 0
                     mapOf<String, Any>("id" to clientId, "fullName" to row[Users.fullName],
                         "initials" to row[Users.fullName].split(" ").map { it.first() }.joinToString(""),
-                        "calories" to (summary["calories"] ?: BigDecimal.ZERO), "goalCalories" to goalCal,
+                        "calories" to (summary["calories"] ?: BigDecimal.ZERO).fmt(0), "goalCalories" to goalCal.fmt(0),
                         "compliance" to pct.coerceAtMost(100), "status" to if (pct >= 60) "On Track" else "Needs Attention")
                 }
         }
@@ -71,15 +72,38 @@ fun Route.professionalRoutes() {
         val entries = DiaryService.getEntriesForDate(clientId, date); val summary = DiaryService.getDailySummary(clientId, date)
         val goals = GoalService.getGoals(clientId)
         val meals = listOf("breakfast", "lunch", "snack", "dinner").map { meal ->
-            val me = entries.filter { it["mealType"] == meal }; mapOf("type" to meal, "entries" to me, "calories" to me.sumOf { it["calories"] as BigDecimal })
+            val me = entries.filter { it["mealType"] == meal }
+            val mealCalories = me.sumOf { it["calories"] as BigDecimal }
+            mapOf(
+                "type" to meal,
+                "entries" to me.map { e -> mapOf(
+                    "id" to e["id"],
+                    "foodName" to e["foodName"],
+                    "mealType" to e["mealType"],
+                    "quantity" to (e["quantity"] as BigDecimal).fmt(1),
+                    "calories" to (e["calories"] as BigDecimal).fmt(0),
+                    "protein" to (e["protein"] as BigDecimal).fmt(1),
+                    "carbs" to (e["carbs"] as BigDecimal).fmt(1),
+                    "fat" to (e["fat"] as BigDecimal).fmt(1),
+                    "notes" to e["notes"]
+                ) },
+                "calories" to mealCalories.fmt(0)
+            )
         }
+        val displaySummary = mapOf(
+            "calories" to (summary["calories"] ?: BigDecimal.ZERO).fmt(0),
+            "protein" to (summary["protein"] ?: BigDecimal.ZERO).fmt(1),
+            "carbs" to (summary["carbs"] ?: BigDecimal.ZERO).fmt(1),
+            "fat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1)
+        )
+        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
         call.respond(ThymeleafContent("professional/client-detail", model(
             "session" to session,
             "client" to mapOf<String, Any>("id" to client[Users.id], "fullName" to client[Users.fullName],
                 "initials" to client[Users.fullName].split(" ").map { it.first() }.joinToString("")),
             "date" to date, "dateFormatted" to date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")),
             "prevDate" to date.minusDays(1), "nextDate" to date.plusDays(1),
-            "meals" to meals, "summary" to summary, "goals" to (goals ?: emptyMap()),
+            "meals" to meals, "summary" to displaySummary, "goals" to displayGoals,
             "unreadMessages" to unread, "activePage" to "clients")))
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -2,6 +2,8 @@ package com.goodfood.recipes
 
 import com.goodfood.auth.Users
 import com.goodfood.diary.FoodItems
+import com.goodfood.util.recipeCoverEmoji
+import com.goodfood.util.recipeCoverTone
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -46,13 +48,15 @@ object RecipeService {
         }
         filtered.map { row ->
             val rid = row[Recipes.id]
+            val title = row[Recipes.title]
             val ratings = RecipeRatings.selectAll().where { RecipeRatings.recipeId eq rid }.toList()
             val avgRating = if (ratings.isNotEmpty()) ratings.map { it[RecipeRatings.rating] }.average() else 0.0
-            mapOf("id" to rid, "title" to row[Recipes.title], "description" to row[Recipes.description],
+            mapOf("id" to rid, "title" to title, "description" to row[Recipes.description],
                 "prepTime" to row[Recipes.prepTimeMinutes], "cookTime" to row[Recipes.cookTimeMinutes],
                 "totalTime" to (row[Recipes.prepTimeMinutes] + row[Recipes.cookTimeMinutes]),
                 "servings" to row[Recipes.servings], "difficulty" to row[Recipes.difficulty],
-                "avgRating" to BigDecimal(avgRating).setScale(1, RoundingMode.HALF_UP), "reviewCount" to ratings.size)
+                "avgRating" to BigDecimal(avgRating).setScale(1, RoundingMode.HALF_UP), "reviewCount" to ratings.size,
+                "coverEmoji" to recipeCoverEmoji(title), "coverTone" to recipeCoverTone(title))
         }
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/util/Format.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/util/Format.kt
@@ -1,0 +1,86 @@
+package com.goodfood.util
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Render a [BigDecimal] the way a UI should: integers stay integers
+ * (`2000`, not `2000.00`), and fractions are capped at [maxDecimals]
+ * with trailing zeros stripped (`99.9`, not `99.90`; `100`, not `100.0`).
+ *
+ * The DB columns are declared as `NUMERIC(_, 2)` and round-trip with that
+ * scale baked in, so without this `Thymeleaf` ends up calling `toString()`
+ * on the raw BigDecimal and the user sees the storage scale, not the
+ * intended display precision.
+ */
+fun BigDecimal.fmt(maxDecimals: Int = 1): String {
+    val rounded = this.setScale(maxDecimals, RoundingMode.HALF_UP).stripTrailingZeros()
+    // stripTrailingZeros on values like "100.00" gives a negative scale, which
+    // toString() renders as scientific notation ("1E+2") — toPlainString avoids that.
+    return rounded.toPlainString()
+}
+
+private val timeOfDay = DateTimeFormatter.ofPattern("h:mm a")
+private val monthDayTime = DateTimeFormatter.ofPattern("MMM d, h:mm a")
+private val fullDateTime = DateTimeFormatter.ofPattern("MMM d yyyy, h:mm a")
+
+/**
+ * Humanize a chat-message timestamp:
+ *   - same day  → `Today 4:24 PM`
+ *   - yesterday → `Yesterday 4:24 PM`
+ *   - this year → `Apr 30, 4:24 PM`
+ *   - older     → `Apr 30 2025, 4:24 PM`
+ *
+ * Replaces the raw `LocalDateTime.toString()` form (`2026-04-30T16:24:08.749909`)
+ * we used to leak straight into chat bubbles.
+ */
+fun LocalDateTime.fmtChatTime(now: LocalDateTime = LocalDateTime.now()): String {
+    val today = now.toLocalDate()
+    val msgDate = this.toLocalDate()
+    return when {
+        msgDate == today -> "Today ${this.format(timeOfDay)}"
+        msgDate == today.minusDays(1) -> "Yesterday ${this.format(timeOfDay)}"
+        msgDate.year == today.year -> this.format(monthDayTime)
+        else -> this.format(fullDateTime)
+    }
+}
+
+/**
+ * Pick a cover emoji for a recipe card from a keyword scan over its title.
+ * Falls through to a generic plate when nothing matches. Cheap stand-in for
+ * a real image pipeline — keeps the recipe grid from looking text-only.
+ */
+fun recipeCoverEmoji(title: String): String {
+    val t = title.lowercase()
+    return when {
+        "salad" in t -> "🥗"
+        "salmon" in t || "fish" in t || "tuna" in t -> "🐟"
+        "chicken" in t || "turkey" in t -> "🍗"
+        "beef" in t || "steak" in t || "burger" in t -> "🥩"
+        "egg" in t || "omelette" in t -> "🥚"
+        "rice" in t || "risotto" in t -> "🍚"
+        "noodle" in t || "pasta" in t || "spaghetti" in t -> "🍝"
+        "soup" in t || "stew" in t -> "🥣"
+        "bowl" in t || "oats" in t || "oatmeal" in t || "porridge" in t -> "🥣"
+        "smoothie" in t || "juice" in t || "tea" in t -> "🥤"
+        "fruit" in t || "berry" in t || "apple" in t || "banana" in t -> "🍎"
+        "bread" in t || "toast" in t || "sandwich" in t || "wrap" in t -> "🥪"
+        "pizza" in t -> "🍕"
+        "veggie" in t || "vegetable" in t || "broccoli" in t -> "🥦"
+        else -> "🍽️"
+    }
+}
+
+/**
+ * Pick a stable cover tone (`sage` / `oat` / `clay` / `berry`) for a recipe
+ * card so the grid has visual variety without random reshuffles between
+ * page loads. The hash is masked to a 16-bit window so it stays positive
+ * across JVMs.
+ */
+fun recipeCoverTone(title: String): String {
+    val tones = listOf("sage", "oat", "clay", "berry")
+    val idx = ((title.hashCode().toLong() and 0xFFFF) % tones.size).toInt()
+    return tones[idx]
+}

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -979,17 +979,39 @@ input::placeholder, textarea::placeholder {
     border-radius: var(--radius-md);
     background: var(--color-surface);
     box-shadow: var(--shadow-sm);
+    overflow: hidden;
     transition: transform var(--dur) var(--ease-out), box-shadow var(--dur) var(--ease-out);
 }
 .recipe-card:hover { transform: translateY(-3px); box-shadow: var(--shadow); }
 
 .recipe-card__link {
     display: block;
-    padding: 24px;
     color: inherit;
     text-decoration: none;
 }
 .recipe-card__link:hover { text-decoration: none; }
+
+.recipe-card__cover {
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft));
+}
+.recipe-card__cover--sage  { background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft)); }
+.recipe-card__cover--oat   { background: linear-gradient(135deg, var(--color-cream-warm), var(--color-oat)); }
+.recipe-card__cover--clay  { background: linear-gradient(135deg, var(--color-clay-bg), var(--color-clay-soft)); }
+.recipe-card__cover--berry { background: linear-gradient(135deg, var(--color-berry-soft), #f3c4cf); }
+
+.recipe-card__cover-emoji {
+    font-size: 56px;
+    line-height: 1;
+    filter: drop-shadow(0 2px 4px rgba(31, 42, 35, 0.12));
+}
+
+.recipe-card__body {
+    padding: 20px 24px 24px;
+}
 
 .recipe-card__title {
     margin: 0 0 8px;

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -56,15 +56,20 @@
         <div class="recipe-grid" th:if="${recipes != null and !recipes.isEmpty()}">
             <article class="card recipe-card" th:each="r : ${recipes}">
                 <a th:href="|/recipes/${r.id}|" class="recipe-card__link">
-                    <h2 class="recipe-card__title" th:text="${r.title}">Recipe</h2>
-                    <p class="recipe-card__desc" th:text="${r.description}">Description</p>
-                    <div class="recipe-card__meta">
-                        <span th:text="${r.difficulty}">easy</span>
-                        ·
-                        <span th:text="${r.totalTime}">30</span> min
-                        ·
-                        ★ <span th:text="${r.avgRating}">0</span>
-                        (<span th:text="${r.reviewCount}">0</span>)
+                    <div class="recipe-card__cover" th:classappend="|recipe-card__cover--${r.coverTone}|" aria-hidden="true">
+                        <span class="recipe-card__cover-emoji" th:text="${r.coverEmoji}">🍽️</span>
+                    </div>
+                    <div class="recipe-card__body">
+                        <h2 class="recipe-card__title" th:text="${r.title}">Recipe</h2>
+                        <p class="recipe-card__desc" th:text="${r.description}">Description</p>
+                        <div class="recipe-card__meta">
+                            <span th:text="${r.difficulty}">easy</span>
+                            ·
+                            <span th:text="${r.totalTime}">30</span> min
+                            ·
+                            ★ <span th:text="${r.avgRating}">0</span>
+                            (<span th:text="${r.reviewCount}">0</span>)
+                        </div>
                     </div>
                 </a>
             </article>


### PR DESCRIPTION
## Summary
- **Trailing `.00` everywhere** — Dashboard / Diary / Goals / pro-client-detail were leaking the BigDecimal column scale (`2000.00 kcal`, `80.00 g`, `250.00 g`). Added `BigDecimal.fmt()` (strip trailing zeros + cap decimals) and applied it at the route → template boundary; services keep returning typed `BigDecimal` so aggregations still work.
- **Raw ISO timestamps on Messages** — chat bubbles were showing `2026-04-30T16:24:08.749909`. `MessageService.getConversation` now hands the template a `String` via `fmtChatTime()` — `Today 4:24 PM` / `Yesterday 4:24 PM` / `Apr 30, 4:24 PM` / full-date for older.
- **Bare Recipe cards** — added a tinted gradient cover panel (sage / oat / clay / berry, hashed off the title for stable variety) with a title-derived emoji placeholder, plus `.recipe-card__cover*` styles in `styles.css`.

## Files
- New: `2850final project/src/main/kotlin/com/goodfood/util/Format.kt` — small helpers, no runtime deps.
- Edited: `DashboardRoutes`, `DiaryRoutes`, `GoalRoutes`, `ProfessionalRoutes` (apply `fmt`); `MessageService` (humanise `sentAt`); `RecipeService.searchRecipes` (add `coverEmoji` / `coverTone`); `subscriber/recipes.html` (cover panel markup); `static/css/styles.css` (cover styles).
- `CHANGELOG.md` v0.6.3 entry.

## Test plan
- [ ] CI green on the PR
- [ ] After merge: numbers on Dashboard / Diary / Goals show as integers / 1-decimal-max with no trailing zeros
- [ ] After merge: Messages chat bubbles show humanised time (Today / Yesterday / month-day)
- [ ] After merge: Recipes grid shows coloured cover with emoji per card

Closes #46