### PR TITLE
fix: nullable goal values in v0.6.3 display formatting

### DIFF
--- a/2850final project/src/main/kotlin/com/goodfood/diary/DiaryRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DiaryRoutes.kt
@@ -49,7 +49,7 @@ fun Route.diaryRoutes() {
             "carbs" to (summary["carbs"] ?: BigDecimal.ZERO).fmt(1),
             "fat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1)
         )
-        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
+        val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
         call.respond(ThymeleafContent("subscriber/diary", model(
             "session" to session, "date" to date, "dateFormatted" to date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")),
             "prevDate" to date.minusDays(1), "nextDate" to date.plusDays(1), "meals" to meals, "summary" to displaySummary,

--- a/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
@@ -19,7 +19,7 @@ fun Route.goalRoutes() {
         val goals = GoalService.getGoals(session.userId)
         val weekly = DiaryService.getWeeklySummary(session.userId)
         val unread = MessageService.getUnreadCount(session.userId)
-        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
+        val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
         val displayWeekly = weekly.map { w -> mapOf(
             "date" to w["date"],
             "dayName" to w["dayName"],

--- a/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
@@ -96,7 +96,7 @@ fun Route.professionalRoutes() {
             "carbs" to (summary["carbs"] ?: BigDecimal.ZERO).fmt(1),
             "fat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1)
         )
-        val displayGoals = goals?.mapValues { (_, v) -> v.fmt(1) } ?: emptyMap()
+        val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
         call.respond(ThymeleafContent("professional/client-detail", model(
             "session" to session,
             "client" to mapOf<String, Any>("id" to client[Users.id], "fullName" to client[Users.fullName],


### PR DESCRIPTION
## Summary
Hotfix on top of #47. CI on the original PR caught a Kotlin compile error after the squash merge had already gone in (auto-merge wasn't gated on the check), so main currently won't build.

`GoalService.getGoals()` returns `Map<String, BigDecimal?>?` — values are nullable when the user only set some macros. The new display formatting called `.fmt()` straight on the lambda value, which Kotlin rejects on a nullable receiver.

Three matching call sites get the null-safe fix (`v?.fmt(1) ?: ""`) so blank goal cells render as an empty input rather than `0`:
- `DiaryRoutes.kt`
- `GoalRoutes.kt`
- `ProfessionalRoutes.kt`

## Test plan
- [ ] CI green
- [ ] /goals form pre-fills set values; missing macros render empty inputs
- [ ] After merge: Render redeploys main cleanly