### PR TITLE
fix: dashboard polish — ring, thicker bars, warmer empty states (v0.6.4)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.4] - 2026-05-02 — Dashboard polish: ring, thicker bars, warmer empty states (closes #50)
+
+### Fixed
+- Calories progress was a thin 6px line buried among three other macros — promoted to a conic-gradient ring centrepiece with the absolute number and percent inside.
+- Macro progress bars bumped from 6px to 10px with rounded ends and per-macro gradients (deep-sage → sage on calories, sage → sage-soft on protein, clay → clay-soft on fat).
+- Empty-state copy (`No foods logged for this meal.`, `Nothing logged yet.`, `No data for this week yet.`) replaced with friendlier nudges; diary empty meals point at the **Add food** button.
+
+---
+
 ## [v0.6.3] - 2026-05-01 — UI detail bug fixes (closes #46)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -710,15 +710,127 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     vertical-align: middle;
     margin-right: 8px;
 }
+.progress--lg {
+    height: 10px;
+}
 .progress__fill {
     height: 100%;
     border-radius: var(--radius-pill);
     transition: width var(--dur-slow) var(--ease-out);
 }
 .progress__fill--cal  { background: linear-gradient(90deg, var(--color-sage-deep), var(--color-sage)); }
-.progress__fill--prot { background: var(--color-sage); }
+.progress__fill--prot { background: linear-gradient(90deg, var(--color-sage), var(--color-sage-soft)); }
 .progress__fill--carb { background: var(--color-sage-soft); }
-.progress__fill--fat  { background: var(--color-clay); }
+.progress__fill--fat  { background: linear-gradient(90deg, var(--color-clay), var(--color-clay-soft)); }
+
+/* ============================================================
+   Dashboard summary — calorie ring + macro bars side-by-side
+   ============================================================ */
+.dashboard-summary {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 36px;
+    align-items: center;
+    padding: 28px 32px;
+    margin-bottom: 28px;
+}
+
+.dashboard-summary__ring {
+    text-align: center;
+}
+
+.dashboard-summary__caption {
+    margin: 14px 0 0;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--text-soft);
+    font-weight: 600;
+}
+
+.dashboard-summary__bars {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-width: 0;
+}
+
+.ring {
+    --ring-pct: 0;
+    --ring-thickness: 14px;
+    width: 168px;
+    height: 168px;
+    border-radius: 50%;
+    background: conic-gradient(
+        from -90deg,
+        var(--color-sage-deep) 0%,
+        var(--color-sage) calc(var(--ring-pct) * 1%),
+        var(--color-sage-bg) calc(var(--ring-pct) * 1%) 100%
+    );
+    display: grid;
+    place-items: center;
+    position: relative;
+    margin: 0 auto;
+}
+
+.ring::before {
+    content: '';
+    position: absolute;
+    inset: var(--ring-thickness);
+    background: var(--color-surface);
+    border-radius: 50%;
+}
+
+.ring__center {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    line-height: 1.1;
+}
+.ring__value {
+    display: block;
+    font-size: 34px;
+    font-weight: 700;
+    color: var(--text-strong);
+    letter-spacing: var(--tracking-snug);
+}
+.ring__unit {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--text-soft);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    margin-top: 2px;
+}
+.ring__pct {
+    display: block;
+    margin-top: 8px;
+    font-size: var(--text-xs);
+    font-weight: 700;
+    color: var(--color-sage-deep);
+    letter-spacing: var(--tracking-wide);
+}
+
+.macro-row {
+    display: grid;
+    grid-template-columns: 70px 1fr 130px;
+    align-items: center;
+    gap: 14px;
+}
+.macro-row__label {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--text-soft);
+    font-weight: 600;
+}
+.macro-row__value {
+    font-size: var(--text-sm);
+    color: var(--text-strong);
+    font-weight: 600;
+    text-align: right;
+    white-space: nowrap;
+}
 
 /* ============================================================
    Meals
@@ -797,6 +909,16 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     font-size: var(--text-body);
     margin: 0;
     line-height: var(--leading-snug);
+}
+.empty-hint--soft {
+    padding: 16px 18px;
+    background: var(--color-surface-warm);
+    border-radius: var(--radius-md);
+    border: 1px dashed var(--color-border-soft);
+}
+.empty-hint--soft strong {
+    color: var(--color-sage-deep);
+    font-weight: 700;
 }
 .empty-hint--pad {
     padding: 28px 24px;
@@ -1690,6 +1812,17 @@ input::placeholder, textarea::placeholder {
     .auth-title { font-size: 32px; }
 }
 
+@media (max-width: 720px) {
+    .dashboard-summary {
+        grid-template-columns: 1fr;
+        gap: 24px;
+        padding: 24px 20px;
+    }
+    .macro-row {
+        grid-template-columns: 60px 1fr 110px;
+    }
+}
+
 @media (max-width: 480px) {
     .main { padding: 70px 14px 24px; }
     .macro-grid { grid-template-columns: 1fr; }
@@ -1699,6 +1832,9 @@ input::placeholder, textarea::placeholder {
     .modal__panel { max-width: 100%; padding: 24px; }
     .toast-region { bottom: 12px; right: 12px; left: 12px; }
     .toast { min-width: 0; }
+    .ring { width: 140px; height: 140px; --ring-thickness: 12px; }
+    .ring__value { font-size: 28px; }
+    .macro-row { grid-template-columns: 56px 1fr 100px; gap: 10px; }
 }
 
 @media print {

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -36,33 +36,50 @@
             <p class="page-meta" th:text="${date}">Date</p>
         </header>
 
-        <section class="card macro-grid" aria-label="Daily macros">
-            <div class="macro-card">
-                <h2 class="macro-card__label">Calories</h2>
-                <p class="macro-card__value"><span th:text="${totalCalories}">0</span> / <span th:text="${goalCalories}">2000</span> kcal</p>
-                <div class="progress" role="progressbar" aria-label="Calories progress" th:attr="aria-valuenow=${pctCalories}" aria-valuemin="0" aria-valuemax="100">
-                    <div class="progress__fill progress__fill--cal" th:style="|width: ${pctCalories}%;|"></div>
+        <section class="card dashboard-summary" aria-label="Daily macros">
+            <div class="dashboard-summary__ring">
+                <div class="ring" th:style="|--ring-pct: ${pctCalories};|" role="img"
+                     th:attr="aria-label=|${pctCalories} percent of daily calorie goal|">
+                    <div class="ring__center">
+                        <span class="ring__value" th:text="${totalCalories}">0</span>
+                        <span class="ring__unit">kcal</span>
+                        <span class="ring__pct"><span th:text="${pctCalories}">0</span>% of goal</span>
+                    </div>
                 </div>
+                <p class="dashboard-summary__caption">
+                    <span th:text="${totalCalories}">0</span> / <span th:text="${goalCalories}">2000</span> kcal
+                </p>
             </div>
-            <div class="macro-card">
-                <h2 class="macro-card__label">Protein</h2>
-                <p class="macro-card__value"><span th:text="${totalProtein}">0</span> / <span th:text="${goalProtein}">80</span> g</p>
-                <div class="progress" role="progressbar" aria-label="Protein progress" th:attr="aria-valuenow=${pctProtein}" aria-valuemin="0" aria-valuemax="100">
-                    <div class="progress__fill progress__fill--prot" th:style="|width: ${pctProtein}%;|"></div>
+            <div class="dashboard-summary__bars">
+                <div class="macro-row">
+                    <span class="macro-row__label">Protein</span>
+                    <div class="progress progress--lg" role="progressbar" aria-label="Protein progress"
+                         th:attr="aria-valuenow=${pctProtein}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress__fill progress__fill--prot" th:style="|width: ${pctProtein}%;|"></div>
+                    </div>
+                    <span class="macro-row__value">
+                        <span th:text="${totalProtein}">0</span> / <span th:text="${goalProtein}">80</span> g
+                    </span>
                 </div>
-            </div>
-            <div class="macro-card">
-                <h2 class="macro-card__label">Carbs</h2>
-                <p class="macro-card__value"><span th:text="${totalCarbs}">0</span> / <span th:text="${goalCarbs}">250</span> g</p>
-                <div class="progress" role="progressbar" aria-label="Carbohydrates progress" th:attr="aria-valuenow=${pctCarbs}" aria-valuemin="0" aria-valuemax="100">
-                    <div class="progress__fill progress__fill--carb" th:style="|width: ${pctCarbs}%;|"></div>
+                <div class="macro-row">
+                    <span class="macro-row__label">Carbs</span>
+                    <div class="progress progress--lg" role="progressbar" aria-label="Carbohydrates progress"
+                         th:attr="aria-valuenow=${pctCarbs}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress__fill progress__fill--carb" th:style="|width: ${pctCarbs}%;|"></div>
+                    </div>
+                    <span class="macro-row__value">
+                        <span th:text="${totalCarbs}">0</span> / <span th:text="${goalCarbs}">250</span> g
+                    </span>
                 </div>
-            </div>
-            <div class="macro-card">
-                <h2 class="macro-card__label">Fat</h2>
-                <p class="macro-card__value"><span th:text="${totalFat}">0</span> / <span th:text="${goalFat}">65</span> g</p>
-                <div class="progress" role="progressbar" aria-label="Fat progress" th:attr="aria-valuenow=${pctFat}" aria-valuemin="0" aria-valuemax="100">
-                    <div class="progress__fill progress__fill--fat" th:style="|width: ${pctFat}%;|"></div>
+                <div class="macro-row">
+                    <span class="macro-row__label">Fat</span>
+                    <div class="progress progress--lg" role="progressbar" aria-label="Fat progress"
+                         th:attr="aria-valuenow=${pctFat}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress__fill progress__fill--fat" th:style="|width: ${pctFat}%;|"></div>
+                    </div>
+                    <span class="macro-row__value">
+                        <span th:text="${totalFat}">0</span> / <span th:text="${goalFat}">65</span> g
+                    </span>
                 </div>
             </div>
         </section>
@@ -81,7 +98,7 @@
                     </span>
                 </li>
             </ul>
-            <p class="empty-hint" th:if="${meal.entries == null or meal.entries.isEmpty()}">No foods logged for this meal.</p>
+            <p class="empty-hint" th:if="${meal.entries == null or meal.entries.isEmpty()}">Nothing here yet.</p>
         </section>
     </main>
 </div>

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -73,7 +73,9 @@
                     </form>
                 </li>
             </ul>
-            <p class="empty-hint" th:if="${meal.entries == null or meal.entries.isEmpty()}">Nothing logged yet.</p>
+            <p class="empty-hint empty-hint--soft" th:if="${meal.entries == null or meal.entries.isEmpty()}">
+                Empty plate. Tap <strong>Add food</strong> to log what you had.
+            </p>
         </section>
     </main>
 </div>

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -74,7 +74,7 @@
                         <span class="weekly-chart__val" th:text="${w.calories}">0</span>
                     </div>
                 </div>
-                <p class="empty-hint" th:if="${weekly == null or weekly.isEmpty()}">No data for this week yet.</p>
+                <p class="empty-hint" th:if="${weekly == null or weekly.isEmpty()}">Quiet week so far — log a meal to see progress.</p>
             </section>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- **Calorie ring** — promoted calories from a thin 6px bar to a conic-gradient ring (`from -90deg, sage-deep → sage at \`--ring-pct\`, then sage-bg`) with the absolute number + `% of goal` inside. Sits left of three macro bars on the dashboard summary card.
- **Thicker macro bars** — `.progress--lg` (10px tall, rounded ends) for the dashboard's protein / carbs / fat rows. Per-macro gradient tints (deep-sage→sage on calories, sage→sage-soft on protein, clay→clay-soft on fat) match the v0.6.0 brief.
- **Warmer empty states** — `No foods logged for this meal.` → `Nothing here yet.`; `Nothing logged yet.` → `Empty plate. Tap **Add food** to log what you had.` (with `empty-hint--soft` styling); `No data for this week yet.` → `Quiet week so far — log a meal to see progress.`
- New responsive breakpoint at 720px stacks the ring above the bars.

## Files
- `subscriber/dashboard.html` — restructure macro section into ring + bars layout; soften empty meal copy.
- `subscriber/diary.html` / `subscriber/goals.html` — empty-state copy.
- `static/css/styles.css` — `.dashboard-summary`, `.ring`, `.macro-row`, `.progress--lg`, `.empty-hint--soft` + 720px / 480px breakpoints.
- `CHANGELOG.md` — brief v0.6.4 entry.

## Test plan
- [ ] CI green
- [ ] After merge: Dashboard shows the calorie ring with correct percentage; macro bars are visibly thicker
- [ ] Diary empty meals show the soft hint pointing at Add food; Goals empty week shows the friendlier copy
- [ ] Layout collapses cleanly at 720px and 480px

Closes #50