### PR TITLE
fix: macro typography, date prominence, filter row, sidebar tone (v0.6.5)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.5] - 2026-05-02 — Final polish: macro typography, date prominence, filter row, sidebar tone (closes #52)
+
+### Fixed
+- Macro rows now split current value (body-size, strong) from goal (`/ 80 g` muted) instead of one grey lump.
+- Page-header date bumped from small / soft to base size with a sage-soft left accent bar so the date reads as page context rather than fine print.
+- Recipes filter card collapsed from a 3-row stacked form into a single inline strip (search input + difficulty select + Apply); roughly 60px less vertical air on `/recipes`.
+- Sidebar bg softened from `#1f2a23` to `#2d3d34` (warmer, less editorial); active-link tint lifted to `rgba(184,209,168,0.26)` so the highlight reads on the new bg.
+
+---
+
 ## [v0.6.4] - 2026-05-02 — Dashboard polish: ring, thicker bars, warmer empty states (closes #50)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -75,14 +75,14 @@
 
     --color-progress-track: var(--color-oat);
 
-    /* sidebar — deep forest band, cream text */
-    --sidebar-bg:           var(--color-deep);
-    --sidebar-bg-pro:       #14201a;
+    /* sidebar — softened forest band, warmer than v0.6.0; cream text */
+    --sidebar-bg:           #2d3d34;
+    --sidebar-bg-pro:       #243027;
     --sidebar-text:         var(--color-cream);
-    --sidebar-text-muted:   #9aa498;
-    --sidebar-divider:      rgba(251, 248, 240, 0.10);
-    --sidebar-hover:        rgba(251, 248, 240, 0.06);
-    --sidebar-active:       rgba(184, 209, 168, 0.18);
+    --sidebar-text-muted:   #b3bdaf;
+    --sidebar-divider:      rgba(251, 248, 240, 0.12);
+    --sidebar-hover:        rgba(251, 248, 240, 0.08);
+    --sidebar-active:       rgba(184, 209, 168, 0.26);
 
     /* chat / table / bubble */
     --bubble-them-bg:       var(--color-cream-warm);
@@ -645,9 +645,13 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 }
 
 .page-meta {
-    margin: 6px 0 0;
-    color: var(--text-soft);
-    font-size: var(--text-body);
+    margin: 8px 0 0;
+    color: var(--text);
+    font-size: var(--text-base);
+    font-weight: 500;
+    padding-left: 12px;
+    border-left: 3px solid var(--color-sage-soft);
+    line-height: 1.3;
 }
 
 .card {
@@ -825,11 +829,18 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     font-weight: 600;
 }
 .macro-row__value {
-    font-size: var(--text-sm);
-    color: var(--text-strong);
-    font-weight: 600;
+    font-size: var(--text-body);
     text-align: right;
     white-space: nowrap;
+}
+.macro-row__value strong {
+    color: var(--text-strong);
+    font-weight: 700;
+    font-size: var(--text-base);
+}
+.macro-row__goal {
+    color: var(--text-soft);
+    font-weight: 500;
 }
 
 /* ============================================================
@@ -1085,6 +1096,19 @@ input::placeholder, textarea::placeholder {
     background: var(--color-surface);
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
+}
+.filter-bar--inline {
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+}
+.filter-bar__search {
+    flex: 1 1 240px;
+    min-width: 200px;
+}
+.filter-bar__select {
+    flex: 0 0 auto;
+    min-width: 160px;
 }
 
 /* ============================================================

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -58,7 +58,8 @@
                         <div class="progress__fill progress__fill--prot" th:style="|width: ${pctProtein}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <span th:text="${totalProtein}">0</span> / <span th:text="${goalProtein}">80</span> g
+                        <strong th:text="${totalProtein}">0</strong>
+                        <span class="macro-row__goal"> / <span th:text="${goalProtein}">80</span> g</span>
                     </span>
                 </div>
                 <div class="macro-row">
@@ -68,7 +69,8 @@
                         <div class="progress__fill progress__fill--carb" th:style="|width: ${pctCarbs}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <span th:text="${totalCarbs}">0</span> / <span th:text="${goalCarbs}">250</span> g
+                        <strong th:text="${totalCarbs}">0</strong>
+                        <span class="macro-row__goal"> / <span th:text="${goalCarbs}">250</span> g</span>
                     </span>
                 </div>
                 <div class="macro-row">
@@ -78,7 +80,8 @@
                         <div class="progress__fill progress__fill--fat" th:style="|width: ${pctFat}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <span th:text="${totalFat}">0</span> / <span th:text="${goalFat}">65</span> g
+                        <strong th:text="${totalFat}">0</strong>
+                        <span class="macro-row__goal"> / <span th:text="${goalFat}">65</span> g</span>
                     </span>
                 </div>
             </div>

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -36,20 +36,15 @@
             <p class="page-meta">Browse and cook balanced meals</p>
         </header>
 
-        <form class="card filter-bar" method="get" th:action="'/recipes'">
-            <label class="field field--inline">
-                <span class="field__label">Search</span>
-                <input type="search" name="q" placeholder="Title…" th:value="${query}"/>
-            </label>
-            <label class="field field--inline">
-                <span class="field__label">Difficulty</span>
-                <select name="difficulty" class="input-select">
-                    <option value="all" th:selected="${difficulty == 'all'}">All</option>
-                    <option value="easy" th:selected="${difficulty == 'easy'}">Easy</option>
-                    <option value="medium" th:selected="${difficulty == 'medium'}">Medium</option>
-                    <option value="hard" th:selected="${difficulty == 'hard'}">Hard</option>
-                </select>
-            </label>
+        <form class="filter-bar filter-bar--inline" method="get" th:action="'/recipes'">
+            <input type="search" name="q" placeholder="Search recipes by title…"
+                   th:value="${query}" aria-label="Search recipes" class="filter-bar__search"/>
+            <select name="difficulty" class="input-select filter-bar__select" aria-label="Filter by difficulty">
+                <option value="all" th:selected="${difficulty == 'all'}">All difficulties</option>
+                <option value="easy" th:selected="${difficulty == 'easy'}">Easy</option>
+                <option value="medium" th:selected="${difficulty == 'medium'}">Medium</option>
+                <option value="hard" th:selected="${difficulty == 'hard'}">Hard</option>
+            </select>
             <button type="submit" class="btn btn--primary">Apply</button>
         </form>
 


### PR DESCRIPTION
## Summary
Final polish batch — four small surface-level adjustments, none rebuild logic.

- **Macro typography** — `.macro-row__value` splits into `<strong>` (current, body-size, strong colour) + `.macro-row__goal` (muted `/ 80 g`). Eaten amount now carries the weight instead of merging with the target into one grey lump.
- **Page-header date** — bumped from `text-body` / `--text-soft` to `text-base` / `--text` with a `border-left: 3px solid sage-soft` accent. Reads as page context, not fine print.
- **Recipes filter row** — collapsed the 3-row stacked form into a single inline strip (search + difficulty select + Apply). `field--inline` labels dropped in favour of `placeholder` + `aria-label` for screen readers. New `.filter-bar--inline` modifier reduces padding from 18px to 10px. ~60px less vertical air on `/recipes`.
- **Sidebar tone** — `--sidebar-bg` softened from `#1f2a23` to `#2d3d34` (warmer, less editorial); `--sidebar-active` lifted to `rgba(184, 209, 168, 0.26)` so the active-link highlight still reads on the new bg.

## Files
- `subscriber/dashboard.html` — split macro-row value markup.
- `subscriber/recipes.html` — single-row inline filter form.
- `static/css/styles.css` — `.macro-row__value strong` / `.macro-row__goal`, `.page-meta` accent, `.filter-bar--inline`, sidebar palette tokens.
- `CHANGELOG.md` — v0.6.5 entry.

## Test plan
- [ ] CI green
- [ ] Macro rows on Dashboard read with clear weight hierarchy (current bold, goal muted)
- [ ] Page meta date is more prominent across Dashboard / Diary / Goals / Recipes / Profile / Messages
- [ ] Recipes filter is one row, smaller card; Apply still works
- [ ] Sidebar warmer; active-link still legible against new bg

Closes #52