### PR TITLE
feat: real recipe covers, per-serving nutrition, featured strip (v0.6.6)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.6] - 2026-05-02 — Recipes: real cover photos, per-serving nutrition, Featured strip (closes #54)
+
+### Fixed
+- Seed recipes (`Grilled Chicken Salad`, `Overnight Oats Bowl`, `Grilled Salmon with Veggies`) now ship with real Unsplash cover photos via an idempotent `SeedData.backfillImageUrls()` that runs on every boot. User-added recipes still fall back to the emoji cover.
+- Recipe cards now show per-serving calories and protein under the description (`320 kcal · 28g protein per serving`) — same nutrition logic that already powered the detail page, lifted into `searchRecipes` via a shared `summariseRow` helper.
+- Added a `Featured this week` strip above the search filter, showing the top 3 recipes by average rating (ties broken by review count). Hidden when the user has applied a search or difficulty filter so it doesn't fight the results.
+
+---
+
 ## [v0.6.5] - 2026-05-02 — Final polish: macro typography, date prominence, filter row, sidebar tone (closes #52)
 
 ### Fixed

--- a/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
@@ -69,4 +69,7 @@ fun Application.configureDatabase() {
     }
 
     SeedData.insertIfEmpty()
+    // Idempotent — fills in image_url on the seed recipes for any DB that
+    // came up before that column was being populated. Safe on every boot.
+    SeedData.backfillImageUrls()
 }

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeRoutes.kt
@@ -15,9 +15,14 @@ fun Route.recipeRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         val query = call.request.queryParameters["q"]; val difficulty = call.request.queryParameters["difficulty"]
         val recipes = RecipeService.searchRecipes(query, difficulty)
+        // Only show the Featured strip on the unfiltered landing — when the user
+        // is searching, hide it so the page is just their results.
+        val featured = if (query.isNullOrBlank() && (difficulty.isNullOrBlank() || difficulty == "all"))
+            RecipeService.getFeatured(3) else emptyList()
         val unread = MessageService.getUnreadCount(session.userId)
         call.respond(ThymeleafContent("subscriber/recipes", model(
-            "session" to session, "recipes" to recipes, "query" to (query ?: ""), "difficulty" to (difficulty ?: "all"),
+            "session" to session, "recipes" to recipes, "featured" to featured,
+            "query" to (query ?: ""), "difficulty" to (difficulty ?: "all"),
             "unreadMessages" to unread, "activePage" to "recipes")))
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -29,12 +29,60 @@ object RecipeService {
         input.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     /**
+     * Compute the per-serving macros for a recipe by summing each ingredient's
+     * scaled nutrition (factor = `quantity / 100g`) and dividing by `servings`.
+     * Returns a four-element pair-of-pairs: cal, protein, carbs, fat. Used by
+     * both [searchRecipes] (card meta line) and [getRecipeDetail].
+     */
+    private fun perServingMacros(recipeId: Int, servings: Int): Map<String, BigDecimal> {
+        val ingredients = RecipeIngredients.selectAll().where { RecipeIngredients.recipeId eq recipeId }.toList()
+        var cal = BigDecimal.ZERO; var prot = BigDecimal.ZERO; var carb = BigDecimal.ZERO; var fat = BigDecimal.ZERO
+        for (row in ingredients) {
+            val fid = row[RecipeIngredients.foodItemId] ?: continue
+            val food = FoodItems.selectAll().where { FoodItems.id eq fid }.singleOrNull() ?: continue
+            val qty = try { BigDecimal(row[RecipeIngredients.quantity]) } catch (_: Exception) { continue }
+            val factor = qty.divide(BigDecimal(100), 4, RoundingMode.HALF_UP)
+            cal += food[FoodItems.caloriesPer100g] * factor; prot += food[FoodItems.proteinPer100g] * factor
+            carb += food[FoodItems.carbsPer100g] * factor; fat += food[FoodItems.fatPer100g] * factor
+        }
+        val s = servings.toBigDecimal()
+        return mapOf(
+            "cal" to cal.divide(s, 0, RoundingMode.HALF_UP),
+            "prot" to prot.divide(s, 1, RoundingMode.HALF_UP),
+            "carb" to carb.divide(s, 1, RoundingMode.HALF_UP),
+            "fat" to fat.divide(s, 1, RoundingMode.HALF_UP)
+        )
+    }
+
+    /**
+     * Build the card-shaped summary map for a single recipe row — covers the
+     * `/recipes` listing and the `Featured this week` strip. Inside `transaction`.
+     */
+    private fun summariseRow(row: org.jetbrains.exposed.sql.ResultRow): Map<String, Any?> {
+        val rid = row[Recipes.id]
+        val title = row[Recipes.title]
+        val servings = row[Recipes.servings]
+        val ratings = RecipeRatings.selectAll().where { RecipeRatings.recipeId eq rid }.toList()
+        val avgRating = if (ratings.isNotEmpty()) ratings.map { it[RecipeRatings.rating] }.average() else 0.0
+        val macros = perServingMacros(rid, servings)
+        return mapOf("id" to rid, "title" to title, "description" to row[Recipes.description],
+            "prepTime" to row[Recipes.prepTimeMinutes], "cookTime" to row[Recipes.cookTimeMinutes],
+            "totalTime" to (row[Recipes.prepTimeMinutes] + row[Recipes.cookTimeMinutes]),
+            "servings" to servings, "difficulty" to row[Recipes.difficulty],
+            "avgRating" to BigDecimal(avgRating).setScale(1, RoundingMode.HALF_UP), "reviewCount" to ratings.size,
+            "imageUrl" to row[Recipes.imageUrl],
+            "coverEmoji" to recipeCoverEmoji(title), "coverTone" to recipeCoverTone(title),
+            "calPerServing" to macros["cal"], "protPerServing" to macros["prot"])
+    }
+
+    /**
      * Title-substring + difficulty filter. Both filters are optional.
      *
      * @param query case-insensitive substring of the recipe title; wildcard-escaped.
      * @param difficulty `"easy"`, `"medium"`, `"hard"`, or `"all"` / `null` to skip.
      * @return one map per recipe with id, title, description, prep/cook/total time,
-     *  servings, difficulty, average rating, and review count.
+     *  servings, difficulty, average rating, review count, cover image / fallback
+     *  emoji + tone, and per-serving calories / protein.
      */
     fun searchRecipes(query: String?, difficulty: String?): List<Map<String, Any?>> = transaction {
         val baseQuery = Recipes.selectAll()
@@ -46,18 +94,20 @@ object RecipeService {
             if (!difficulty.isNullOrBlank() && difficulty != "all") q.andWhere { Recipes.difficulty eq difficulty }
             q
         }
-        filtered.map { row ->
-            val rid = row[Recipes.id]
-            val title = row[Recipes.title]
-            val ratings = RecipeRatings.selectAll().where { RecipeRatings.recipeId eq rid }.toList()
-            val avgRating = if (ratings.isNotEmpty()) ratings.map { it[RecipeRatings.rating] }.average() else 0.0
-            mapOf("id" to rid, "title" to title, "description" to row[Recipes.description],
-                "prepTime" to row[Recipes.prepTimeMinutes], "cookTime" to row[Recipes.cookTimeMinutes],
-                "totalTime" to (row[Recipes.prepTimeMinutes] + row[Recipes.cookTimeMinutes]),
-                "servings" to row[Recipes.servings], "difficulty" to row[Recipes.difficulty],
-                "avgRating" to BigDecimal(avgRating).setScale(1, RoundingMode.HALF_UP), "reviewCount" to ratings.size,
-                "coverEmoji" to recipeCoverEmoji(title), "coverTone" to recipeCoverTone(title))
-        }
+        filtered.map { summariseRow(it) }
+    }
+
+    /**
+     * Top [limit] recipes by average rating (ties broken by review count, then
+     * by recipe id for stability). Powers the `Featured this week` strip on
+     * `/recipes`. Recipes with zero ratings sort last.
+     */
+    fun getFeatured(limit: Int = 3): List<Map<String, Any?>> = transaction {
+        Recipes.selectAll().map { summariseRow(it) }
+            .sortedWith(compareByDescending<Map<String, Any?>> { (it["avgRating"] as BigDecimal) }
+                .thenByDescending { it["reviewCount"] as Int }
+                .thenBy { it["id"] as Int })
+            .take(limit)
     }
 
     /**

--- a/2850final project/src/main/kotlin/com/goodfood/seed/SeedData.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/seed/SeedData.kt
@@ -6,15 +6,41 @@ import com.goodfood.diary.*
 import com.goodfood.messages.AdviceMessages
 import com.goodfood.professional.*
 import com.goodfood.recipes.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 object SeedData {
     private fun hash(pw: String): String = BCrypt.withDefaults().hashToString(12, pw.toCharArray())
+
+    /**
+     * Image-URL backfill for the three seed recipes. Idempotent — only sets
+     * `image_url` when the row exists *and* the column is currently null, so
+     * it's safe to run on every boot regardless of whether the deploy started
+     * from a fresh DB or one that's been live since before this column was
+     * being populated.
+     */
+    private val seedRecipeImages = mapOf(
+        "Grilled Chicken Salad" to "https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=800&auto=format&fit=crop&q=80",
+        "Overnight Oats Bowl" to "https://images.unsplash.com/photo-1517673400267-0251440c45dc?w=800&auto=format&fit=crop&q=80",
+        "Grilled Salmon with Veggies" to "https://images.unsplash.com/photo-1467003909585-2f8a72700288?w=800&auto=format&fit=crop&q=80"
+    )
+
+    fun backfillImageUrls() {
+        transaction {
+            for ((title, url) in seedRecipeImages) {
+                Recipes.update({ (Recipes.title eq title) and Recipes.imageUrl.isNull() }) {
+                    it[imageUrl] = url
+                }
+            }
+        }
+    }
 
     fun insertIfEmpty() {
         transaction {
@@ -100,7 +126,8 @@ object SeedData {
             val r1 = Recipes.insert {
                 it[createdBy] = drSarah; it[title] = "Grilled Chicken Salad"
                 it[description] = "A fresh and healthy salad with grilled chicken breast, mixed greens, and a light olive oil dressing."
-                it[prepTimeMinutes] = 10; it[cookTimeMinutes] = 15; it[servings] = 2; it[difficulty] = "easy"; it[createdAt] = now
+                it[prepTimeMinutes] = 10; it[cookTimeMinutes] = 15; it[servings] = 2; it[difficulty] = "easy"
+                it[imageUrl] = seedRecipeImages["Grilled Chicken Salad"]; it[createdAt] = now
             } get Recipes.id
             for ((ing, qty, u) in listOf(Triple("Chicken Breast (grilled)", "200", "g"), Triple("Mixed Salad Greens", "150", "g"),
                 Triple("Cherry Tomatoes", "100", "g"), Triple("Cucumber", "50", "g"), Triple("Olive Oil", "2", "tbsp"))) {
@@ -115,7 +142,8 @@ object SeedData {
             val r2 = Recipes.insert {
                 it[createdBy] = drSarah; it[title] = "Overnight Oats Bowl"
                 it[description] = "A quick and nutritious breakfast bowl prepared the night before."
-                it[prepTimeMinutes] = 10; it[cookTimeMinutes] = 0; it[servings] = 1; it[difficulty] = "easy"; it[createdAt] = now
+                it[prepTimeMinutes] = 10; it[cookTimeMinutes] = 0; it[servings] = 1; it[difficulty] = "easy"
+                it[imageUrl] = seedRecipeImages["Overnight Oats Bowl"]; it[createdAt] = now
             } get Recipes.id
             for ((ing, qty, u) in listOf(Triple("Oatmeal", "80", "g"), Triple("Greek Yogurt", "100", "g"),
                 Triple("Banana", "1", "medium"), Triple("Chia Seeds", "15", "g"), Triple("Almonds", "20", "g"))) {
@@ -129,7 +157,8 @@ object SeedData {
             val r3 = Recipes.insert {
                 it[createdBy] = drSarah; it[title] = "Grilled Salmon with Veggies"
                 it[description] = "Omega-3 rich salmon fillet with roasted broccoli and sweet potato."
-                it[prepTimeMinutes] = 15; it[cookTimeMinutes] = 25; it[servings] = 2; it[difficulty] = "medium"; it[createdAt] = now
+                it[prepTimeMinutes] = 15; it[cookTimeMinutes] = 25; it[servings] = 2; it[difficulty] = "medium"
+                it[imageUrl] = seedRecipeImages["Grilled Salmon with Veggies"]; it[createdAt] = now
             } get Recipes.id
             for ((ing, qty, u) in listOf(Triple("Salmon (grilled)", "300", "g"), Triple("Broccoli", "200", "g"),
                 Triple("Sweet Potato", "200", "g"), Triple("Olive Oil", "1", "tbsp"))) {

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1138,12 +1138,22 @@ input::placeholder, textarea::placeholder {
 .recipe-card__link:hover { text-decoration: none; }
 
 .recipe-card__cover {
-    height: 120px;
+    height: 160px;
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
     background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft));
 }
+.recipe-card__cover-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform var(--dur-slow) var(--ease-out);
+}
+.recipe-card:hover .recipe-card__cover-img { transform: scale(1.04); }
+
 .recipe-card__cover--sage  { background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft)); }
 .recipe-card__cover--oat   { background: linear-gradient(135deg, var(--color-cream-warm), var(--color-oat)); }
 .recipe-card__cover--clay  { background: linear-gradient(135deg, var(--color-clay-bg), var(--color-clay-soft)); }
@@ -1156,7 +1166,135 @@ input::placeholder, textarea::placeholder {
 }
 
 .recipe-card__body {
-    padding: 20px 24px 24px;
+    padding: 18px 22px 22px;
+}
+
+.recipe-card__nutrition {
+    margin: 10px 0 12px;
+    font-size: var(--text-sm);
+    color: var(--text-strong);
+    font-weight: 600;
+    line-height: var(--leading-snug);
+}
+.recipe-card__per {
+    color: var(--text-soft);
+    font-weight: 500;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    margin-left: 6px;
+}
+
+/* ============================================================
+   Featured this week — top-rated strip above the recipe grid
+   ============================================================ */
+.featured {
+    margin-bottom: 28px;
+}
+.featured__title {
+    margin: 0 0 14px;
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--text-strong);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.featured__title::before {
+    content: '';
+    width: 24px;
+    height: 2px;
+    background: var(--color-sage);
+    border-radius: var(--radius-pill);
+}
+.featured__strip {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+}
+
+.featured-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--dur) var(--ease-out), box-shadow var(--dur) var(--ease-out);
+}
+.featured-card:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow);
+}
+.featured-card__link {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+}
+.featured-card__link:hover { text-decoration: none; }
+
+.featured-card__cover {
+    position: relative;
+    height: 140px;
+    overflow: hidden;
+}
+.featured-card__cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform var(--dur-slow) var(--ease-out);
+}
+.featured-card:hover .featured-card__cover img { transform: scale(1.05); }
+
+.featured-card__cover-fallback {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 48px;
+    line-height: 1;
+}
+
+.featured-card__badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: rgba(31, 42, 35, 0.78);
+    color: var(--color-cream);
+    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-snug);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+.featured-card__body {
+    padding: 14px 18px 18px;
+}
+.featured-card__title {
+    margin: 0 0 6px;
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--text-strong);
+    line-height: var(--leading-snug);
+}
+.featured-card__nutrition {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-strong);
+    font-weight: 600;
+}
+.featured-card__per {
+    color: var(--text-soft);
+    font-weight: 500;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    margin-left: 4px;
 }
 
 .recipe-card__title {
@@ -1844,6 +1982,10 @@ input::placeholder, textarea::placeholder {
     }
     .macro-row {
         grid-template-columns: 60px 1fr 110px;
+    }
+    .featured__strip {
+        grid-template-columns: 1fr;
+        gap: 14px;
     }
 }
 

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -36,6 +36,32 @@
             <p class="page-meta">Browse and cook balanced meals</p>
         </header>
 
+        <section class="featured" th:if="${featured != null and !featured.isEmpty()}" aria-label="Featured this week">
+            <h2 class="featured__title">Featured this week</h2>
+            <div class="featured__strip">
+                <article class="featured-card" th:each="f : ${featured}">
+                    <a th:href="|/recipes/${f.id}|" class="featured-card__link">
+                        <div class="featured-card__cover">
+                            <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}" loading="lazy"/>
+                            <div th:if="${f.imageUrl == null}" class="featured-card__cover-fallback"
+                                 th:classappend="|recipe-card__cover--${f.coverTone}|">
+                                <span th:text="${f.coverEmoji}">🍽️</span>
+                            </div>
+                            <span class="featured-card__badge">★ <span th:text="${f.avgRating}">0</span></span>
+                        </div>
+                        <div class="featured-card__body">
+                            <h3 class="featured-card__title" th:text="${f.title}">Recipe</h3>
+                            <p class="featured-card__nutrition">
+                                <span th:text="${f.calPerServing}">320</span> kcal ·
+                                <span th:text="${f.protPerServing}">28</span>g protein
+                                <span class="featured-card__per">per serving</span>
+                            </p>
+                        </div>
+                    </a>
+                </article>
+            </div>
+        </section>
+
         <form class="filter-bar filter-bar--inline" method="get" th:action="'/recipes'">
             <input type="search" name="q" placeholder="Search recipes by title…"
                    th:value="${query}" aria-label="Search recipes" class="filter-bar__search"/>
@@ -51,12 +77,18 @@
         <div class="recipe-grid" th:if="${recipes != null and !recipes.isEmpty()}">
             <article class="card recipe-card" th:each="r : ${recipes}">
                 <a th:href="|/recipes/${r.id}|" class="recipe-card__link">
-                    <div class="recipe-card__cover" th:classappend="|recipe-card__cover--${r.coverTone}|" aria-hidden="true">
-                        <span class="recipe-card__cover-emoji" th:text="${r.coverEmoji}">🍽️</span>
+                    <div class="recipe-card__cover" th:classappend="${r.imageUrl == null} ? |recipe-card__cover--${r.coverTone}|">
+                        <img th:if="${r.imageUrl != null}" th:src="${r.imageUrl}" th:alt="${r.title}" loading="lazy" class="recipe-card__cover-img"/>
+                        <span th:if="${r.imageUrl == null}" class="recipe-card__cover-emoji" th:text="${r.coverEmoji}" aria-hidden="true">🍽️</span>
                     </div>
                     <div class="recipe-card__body">
                         <h2 class="recipe-card__title" th:text="${r.title}">Recipe</h2>
                         <p class="recipe-card__desc" th:text="${r.description}">Description</p>
+                        <p class="recipe-card__nutrition">
+                            <span th:text="${r.calPerServing}">320</span> kcal ·
+                            <span th:text="${r.protPerServing}">28</span>g protein
+                            <span class="recipe-card__per">per serving</span>
+                        </p>
                         <div class="recipe-card__meta">
                             <span th:text="${r.difficulty}">easy</span>
                             ·


### PR DESCRIPTION
## Summary
The `/recipes` page after v0.6.5 was still text-with-emoji-covers, no nutrition info, no curation. Three additions on top of data that's already in the schema (`recipes.image_url` was declared but unused).

- **Real cover photos** for the seed recipes. Hand-picked Unsplash CDN URLs hardcoded in `SeedData.seedRecipeImages`. New `backfillImageUrls()` runs every boot and only updates rows where `image_url IS NULL` and the title matches — idempotent, so the live Render PostgreSQL gets the URLs filled in without a manual SQL migration. User-added recipes still fall back to the emoji-on-gradient cover (`recipe-card__cover--{sage|oat|clay|berry}`).
- **Per-serving nutrition on cards.** New `.recipe-card__nutrition` row shows `kcal · g protein per serving`. Logic extracted from `getRecipeDetail` into a private `perServingMacros(recipeId, servings)` helper used by both `searchRecipes` and `getFeatured` via a shared `summariseRow(row)`.
- **Featured this week strip.** New `RecipeService.getFeatured(limit)` returns top recipes by avg rating (ties broken by review count, then id). Rendered as a 3-column grid above the filter, with a translucent `★ rating` badge top-right of each cover. Hidden when the user has typed a query or picked a difficulty so the results page is just results.

## Files
- `Recipes.kt` — already had `image_url` declared, no schema change.
- `SeedData.kt` — `seedRecipeImages` map, set `imageUrl` on inserts, new `backfillImageUrls()`.
- `Database.kt` — call `SeedData.backfillImageUrls()` after `insertIfEmpty()`.
- `RecipeService.kt` — new `perServingMacros`, `summariseRow`, `getFeatured`; `searchRecipes` rewritten to use them.
- `RecipeRoutes.kt` — pass `featured` to `subscriber/recipes` model (only when no filters applied).
- `subscriber/recipes.html` — `<section class="featured">`, image+fallback markup, nutrition row.
- `static/css/styles.css` — `.recipe-card__cover img` (object-cover + hover scale), `.recipe-card__nutrition`, `.featured` / `.featured-card` / `.featured-card__badge`, plus 720px breakpoint that stacks the featured strip.
- `CHANGELOG.md` — v0.6.6 brief.

## Test plan
- [ ] CI green
- [ ] After merge: `/recipes` shows the three seed recipes with real food photos in both the Featured strip and the grid below
- [ ] Each card shows `<n> kcal · <m>g protein per serving`
- [ ] Searching or filtering hides the Featured strip
- [ ] Image alt text + lazy loading present
- [ ] Existing emoji fallback still kicks in if `imageUrl` is null

Closes #54