### PR TITLE
fix: unified radius, larger card padding, mint accent (v0.6.7)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.7] - 2026-05-02 — UI tier-up: unified radius, larger card padding, mint accent (closes #56)
+
+### Fixed
+- Corner radii collapsed onto a single 14px family — `--radius-md` 16→14, `--radius-sm` 8→10, `--radius-lg` 20→18 — so cards / buttons / modals all live in the same geometric tier.
+- `.card` padding bumped from 24px to 28px, `.recipe-card__body` from 18px to 20px so cards breathe like the dashboard summary already does.
+- New `--color-mint` (#b1dbb8) and `--color-mint-bg` (#e1f4df) palette tokens with dark-mode counterparts; the `Featured this week` heading underline now uses mint as a distinct accent from the rest of the sage-on-cream layout.
+
+---
+
 ## [v0.6.6] - 2026-05-02 — Recipes: real cover photos, per-serving nutrition, Featured strip (closes #54)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -33,6 +33,9 @@
     --color-sage-soft:    #b8d1a8;
     --color-sage-bg:      #e8efe1;
 
+    --color-mint:         #b1dbb8;   /* fresher accent than sage-soft */
+    --color-mint-bg:      #e1f4df;   /* lightest sage tier — surface differentiation w/o shadows */
+
     --color-clay:         #d97757;   /* warm accent — kept from v0.5 */
     --color-clay-soft:    #f3d9cc;
     --color-clay-bg:      #fbeae0;
@@ -98,11 +101,12 @@
     --shadow-lg: 0 16px 48px rgba(31, 42, 35, 0.10), 0 0 0 1px rgba(31, 42, 35, 0.04);
     --ring:      0 0 0 3px rgba(94, 125, 79, 0.30);
 
-    /* radii */
-    --radius-sm:   8px;
+    /* radii — collapsed onto a single 14px family for cards / buttons / modals,
+       with 10px for tighter inputs and 18px for hero-tier elements. */
+    --radius-sm:   10px;
     --radius:      14px;
-    --radius-md:   16px;
-    --radius-lg:   20px;
+    --radius-md:   14px;
+    --radius-lg:   18px;
     --radius-pill: 999px;
 
     /* type */
@@ -158,6 +162,9 @@
         --color-primary-soft: #2c3a2e;
         --color-primary-on:   #14201a;
 
+        --color-mint:         #8ab092;
+        --color-mint-bg:      #2a3a2c;
+
         --color-accent:       #e8a584;
         --color-warn:         #e8a584;
         --color-warn-soft:    #3a2820;
@@ -210,6 +217,9 @@
     --color-primary-hover:#bdd4af;
     --color-primary-soft: #2c3a2e;
     --color-primary-on:   #14201a;
+
+    --color-mint:         #8ab092;
+    --color-mint-bg:      #2a3a2c;
 
     --color-accent:       #e8a584;
     --color-warn:         #e8a584;
@@ -658,7 +668,7 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     background: var(--color-surface);
     border-radius: var(--radius-md);
     border: none;
-    padding: 24px;
+    padding: 28px;
     box-shadow: var(--shadow-sm);
     transition: background var(--dur) var(--ease), transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
 }
@@ -1166,7 +1176,7 @@ input::placeholder, textarea::placeholder {
 }
 
 .recipe-card__body {
-    padding: 18px 22px 22px;
+    padding: 20px 24px 24px;
 }
 
 .recipe-card__nutrition {
@@ -1204,9 +1214,9 @@ input::placeholder, textarea::placeholder {
 }
 .featured__title::before {
     content: '';
-    width: 24px;
-    height: 2px;
-    background: var(--color-sage);
+    width: 28px;
+    height: 3px;
+    background: var(--color-mint);
     border-radius: var(--radius-pill);
 }
 .featured__strip {


### PR DESCRIPTION
## Summary
Token-level UI tightening based on a comparison against a curated wellness-SaaS reference. Four small moves; no markup changed.

- **Radius unification.** Cards / buttons / modals now share one family. `--radius-md` 16→14 (cards match the button radius), `--radius-sm` 8→10 (input pills stop reading as a separate tier), `--radius-lg` 20→18 (less aggressive hero tier).
- **Card padding bump.** `.card` 24→28; `.recipe-card__body` 18→20. Cards now breathe like the dashboard summary card already does.
- **Mint palette tokens.** New `--color-mint` (#b1dbb8) and `--color-mint-bg` (#e1f4df) for surface differentiation that doesn't rely on another shadow layer. Dark-mode counterparts at `#8ab092` / `#2a3a2c` keep parity.
- **Mint accent.** `Featured this week` heading underline picks up mint, giving the strip its own accent against the sage-on-cream rest-of-page.

## Files
- `static/css/styles.css` — token edits (light + dark), `.card` padding, `.recipe-card__body` padding, `.featured__title::before` colour.
- `CHANGELOG.md` — brief v0.6.7.

## Test plan
- [ ] CI green
- [ ] After merge: every card has the same 14px corners (no mix of 14 / 16 / 20)
- [ ] Cards visibly more spacious without losing density
- [ ] `Featured this week` underline reads mint, not sage
- [ ] Dark mode still legible

Closes #56