### PR TITLE
fix: a11y + perf audit pass — focus, skip-link, image dims (v0.6.10)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.10] - 2026-05-02 — A11y / perf audit: focus, skip-link, image dims (closes #62)
+
+### Fixed
+- Global `:focus-visible` now pairs the soft `--ring` box-shadow with a 2px solid `--color-primary` outline + offset, so keyboard focus is unambiguously visible across themes and browsers.
+- Skip-to-main-content link added to every authenticated app shell template (subscriber + professional, 10 templates) and revealed on focus; `<main>` carries `id="main"` as the target.
+- Recipe cover `<img>` tags now declare `width="800" height="500"` for explicit aspect ratio, preventing CLS while the image loads.
+- Confirmed already-in-place: `font-display: swap` (Google Fonts URL), `role="alert"` on login errors, and implicit `<label>`-wrap association on every form. No change needed; documented for the audit trail.
+
+---
+
 ## [v0.6.9] - 2026-05-02 — Demo polish: today-anchor seeds, unrated rating, empty-day CTA (closes #60)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -292,9 +292,31 @@ a {
 a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-underline-offset: 3px; }
 
 :focus-visible {
-    outline: none;
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
     box-shadow: var(--ring);
     border-radius: var(--radius-sm);
+}
+
+.skip-link {
+    position: absolute;
+    top: -100px;
+    left: 14px;
+    z-index: 1000;
+    padding: 10px 18px;
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    box-shadow: var(--shadow);
+    transition: top var(--dur) var(--ease-out);
+}
+.skip-link:focus {
+    top: 14px;
+    text-decoration: none;
+    color: var(--color-primary-on);
 }
 
 /* ============================================================

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -26,7 +27,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <p class="back-row"><a th:href="'/pro/dashboard'" class="link-back">← All clients</a></p>
 
         <header class="page-header page-header--row">

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -26,7 +27,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header page-header--row">
             <div>
                 <h1 class="page-title">Client overview</h1>

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -26,7 +27,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main main--chat">
+    <main id="main" class="main main--chat">
         <header class="page-header">
             <h1 class="page-title">Messages</h1>
             <p class="page-meta">Message your clients</p>

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header">
             <h1 class="page-title">Today’s nutrition</h1>
             <p class="page-meta" th:text="${date}">Date</p>

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header page-header--row">
             <div>
                 <h1 class="page-title">Food diary</h1>

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header">
             <h1 class="page-title">Nutrition goals</h1>
             <p class="page-meta">Daily targets power your dashboard progress bars</p>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main main--chat">
+    <main id="main" class="main main--chat">
         <header class="page-header">
             <h1 class="page-title">Messages</h1>
             <p class="page-meta">Chat with your nutrition professional</p>

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header">
             <h1 class="page-title">Your profile</h1>
             <p class="page-meta">Account details and saved recipes</p>

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <p class="back-row"><a th:href="'/recipes'" class="link-back">← All recipes</a></p>
 
         <header class="recipe-hero card">

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
+<a href="#main" class="skip-link">Skip to main content</a>
 <button type="button" class="menu-toggle js-menu-toggle" aria-label="Open menu" aria-expanded="false">☰</button>
 <div class="sidebar-backdrop js-sidebar-backdrop" aria-hidden="true"></div>
 <div class="app-layout">
@@ -30,7 +31,7 @@
         <button type="button" class="sidebar__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <a th:href="'/logout'" class="nav-link nav-link--muted sidebar__logout">Log out</a>
     </aside>
-    <main class="main">
+    <main id="main" class="main">
         <header class="page-header">
             <h1 class="page-title">Recipes</h1>
             <p class="page-meta">Browse and cook balanced meals</p>
@@ -42,7 +43,8 @@
                 <article class="featured-card" th:each="f : ${featured}">
                     <a th:href="|/recipes/${f.id}|" class="featured-card__link">
                         <div class="featured-card__cover">
-                            <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}" loading="lazy"/>
+                            <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}"
+                                 width="800" height="500" loading="lazy"/>
                             <div th:if="${f.imageUrl == null}" class="featured-card__cover-fallback"
                                  th:classappend="|recipe-card__cover--${f.coverTone}|">
                                 <span th:text="${f.coverEmoji}">🍽️</span>
@@ -78,7 +80,8 @@
             <article class="card recipe-card" th:each="r : ${recipes}">
                 <a th:href="|/recipes/${r.id}|" class="recipe-card__link">
                     <div class="recipe-card__cover" th:classappend="${r.imageUrl == null} ? |recipe-card__cover--${r.coverTone}|">
-                        <img th:if="${r.imageUrl != null}" th:src="${r.imageUrl}" th:alt="${r.title}" loading="lazy" class="recipe-card__cover-img"/>
+                        <img th:if="${r.imageUrl != null}" th:src="${r.imageUrl}" th:alt="${r.title}"
+                             width="800" height="500" loading="lazy" class="recipe-card__cover-img"/>
                         <span th:if="${r.imageUrl == null}" class="recipe-card__cover-emoji" th:text="${r.coverEmoji}" aria-hidden="true">🍽️</span>
                     </div>
                     <div class="recipe-card__body">


### PR DESCRIPTION
## Summary
UI/UX-Pro-Max rule audit pass. Of the five items the skill flagged, three were already in place (good news for the audit trail), two needed fixing, and one bonus a11y improvement was added.

### Already in place (no change, documented for the audit)
- **`font-display: swap`** — already present in the Google Fonts `@import url(...)` URL.
- **`role="alert"`** — login error block already wraps content with `role="alert"` (`auth/login.html:26`).
- **Form labels** — every form uses the `<label class="field"><span class="field__label">…</span><input/></label>` wrapping pattern, which is HTML-spec implicit association. The Messages textarea uses an explicit `<label class="sr-only" for="msg-input">`. The Recipes filter input/select carry `aria-label`.

### Fixed
- **Focus visibility** — `:focus-visible` now pairs the soft `--ring` box-shadow with a `2px solid var(--color-primary)` outline + 2px offset. Defense-in-depth: works on rounded corners (box-shadow) AND legacy / high-contrast modes (outline).
- **Image CLS** — Recipe cover `<img>` tags get explicit `width="800" height="500"` so the browser reserves aspect ratio during lazy load. Both Featured strip and grid covered.

### Added
- **Skip-to-main-content link** in all 10 authenticated app shell templates (7 subscriber + 3 professional). `<a href="#main" class="skip-link">` injected just after `<body>`; CSS hides it off-canvas (`top: -100px`) and slides it in on `:focus`. `<main>` carries `id="main"` as the target. Keyboard users can jump past the sidebar nav on every page.

## Files
- `static/css/styles.css` — `:focus-visible` strengthened, `.skip-link` block added.
- 10 templates — skip-link + `id="main"` injected via a single batched script (no manual drift).
- 1 template — `width`/`height` on cover images.
- `CHANGELOG.md` — brief v0.6.10.

## Test plan
- [ ] CI green
- [ ] Tab-navigate any subscriber page from page load: first focus stop is the (visible) skip link
- [ ] Tab through any form: visible outline + sage ring on every focused control
- [ ] DevTools → Performance → Cumulative Layout Shift = 0 on /recipes load
- [ ] Screen reader (VoiceOver / NVDA) hears "Invalid email or password" announcement on login failure

Closes #62