### PR TITLE
feat: motion pass — stagger, ring fill, count-up, shimmer (v0.6.11)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.11] - 2026-05-02 — Motion pass: stagger reveal, ring fill, count-up, shimmer (closes #64)
+
+### Added
+- Stagger reveal on Dashboard macro rows + Recipes grid via `@keyframes stagger-rise` and `--i` index passed inline; 60ms delay per item, ~420ms duration, spring `cubic-bezier(0.16, 1, 0.3, 1)`.
+- Calorie ring fills from 0% to target on mount via `@property --ring-pct` (registered custom property) + 0.85s spring transition.
+- `initCountUp()` in `app.js`: `[data-count-up]` numeric elements tween from 0 to their final value over 700ms with ease-out cubic; preserves integer / single-decimal formatting from the rendered text.
+- One-shot shimmer pass on the calorie / protein / carbs / fat progress bars 0.9s after page settle — fires once, never loops.
+- All four motion features gated under `@media (prefers-reduced-motion: no-preference)`; `initCountUp()` early-returns when the user prefers reduced motion.
+
+### Notes
+- Hover transitions across cards / buttons already used the spring `--ease-out` curve from earlier passes; no change needed for that bullet.
+
+---
+
 ## [v0.6.10] - 2026-05-02 — A11y / perf audit: focus, skip-link, image dims (closes #62)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1976,6 +1976,56 @@ input::placeholder, textarea::placeholder {
     to   { opacity: 1; transform: translateY(0); }
 }
 
+/* ============================================================
+   Motion: stagger reveal, ring fill, one-shot shimmer.
+   All gated behind prefers-reduced-motion: no-preference.
+   ============================================================ */
+@keyframes stagger-rise {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes shimmer-once {
+    0%   { transform: translateX(-100%); }
+    100% { transform: translateX(220%); }
+}
+
+/* @property lets the conic-gradient stop position animate as a real number,
+   not as a string interpolation between gradient images. Without it,
+   the ring would snap rather than fill smoothly. */
+@property --ring-pct {
+    syntax: '<number>';
+    initial-value: 0;
+    inherits: false;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .ring {
+        transition: --ring-pct 0.85s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .recipe-card,
+    .featured-card,
+    .macro-row {
+        opacity: 0;
+        animation: stagger-rise 0.42s var(--ease-out) both;
+        animation-delay: calc(var(--i, 0) * 60ms);
+    }
+
+    .progress--lg {
+        position: relative;
+        overflow: hidden;
+    }
+    .progress--lg::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+        animation: shimmer-once 1.4s 0.9s ease-out 1 both;
+        pointer-events: none;
+    }
+}
+
 .sr-only {
     position: absolute;
     width: 1px;

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -237,6 +237,35 @@
         });
     }
 
+    /* ---- Count-up: numbers tween from 0 to their final value on first paint ---- */
+    function initCountUp() {
+        // Respect the user's motion preference.
+        if (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+        var nodes = document.querySelectorAll("[data-count-up]");
+        if (!nodes.length) return;
+        var DURATION = 700;
+        Array.prototype.forEach.call(nodes, function (el) {
+            var raw = (el.textContent || "").trim();
+            var target = parseFloat(raw);
+            if (isNaN(target)) return;
+            var hasDecimal = raw.indexOf(".") !== -1;
+            var fmt = function (v) {
+                return hasDecimal ? v.toFixed(1) : Math.round(v).toString();
+            };
+            el.textContent = fmt(0);
+            var startedAt = performance.now();
+            function frame(now) {
+                var t = Math.min((now - startedAt) / DURATION, 1);
+                // ease-out cubic
+                var eased = 1 - Math.pow(1 - t, 3);
+                el.textContent = fmt(target * eased);
+                if (t < 1) requestAnimationFrame(frame);
+                else el.textContent = fmt(target);
+            }
+            requestAnimationFrame(frame);
+        });
+    }
+
     /* Apply saved theme synchronously (before DOMContentLoaded) to avoid flash */
     try {
         var early = localStorage.getItem("gf-theme");
@@ -252,5 +281,6 @@
         initStarRating();
         initTheme();
         initSidebarDrawer();
+        initCountUp();
     });
 })();

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -42,9 +42,9 @@
                 <div class="ring" th:style="|--ring-pct: ${pctCalories};|" role="img"
                      th:attr="aria-label=|${pctCalories} percent of daily calorie goal|">
                     <div class="ring__center">
-                        <span class="ring__value" th:text="${totalCalories}">0</span>
+                        <span class="ring__value" th:text="${totalCalories}" data-count-up>0</span>
                         <span class="ring__unit">kcal</span>
-                        <span class="ring__pct"><span th:text="${pctCalories}">0</span>% of goal</span>
+                        <span class="ring__pct"><span th:text="${pctCalories}" data-count-up>0</span>% of goal</span>
                     </div>
                 </div>
                 <p class="dashboard-summary__caption">
@@ -52,36 +52,36 @@
                 </p>
             </div>
             <div class="dashboard-summary__bars">
-                <div class="macro-row">
+                <div class="macro-row" style="--i: 0;">
                     <span class="macro-row__label">Protein</span>
                     <div class="progress progress--lg" role="progressbar" aria-label="Protein progress"
                          th:attr="aria-valuenow=${pctProtein}" aria-valuemin="0" aria-valuemax="100">
                         <div class="progress__fill progress__fill--prot" th:style="|width: ${pctProtein}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <strong th:text="${totalProtein}">0</strong>
+                        <strong th:text="${totalProtein}" data-count-up>0</strong>
                         <span class="macro-row__goal"> / <span th:text="${goalProtein}">80</span> g</span>
                     </span>
                 </div>
-                <div class="macro-row">
+                <div class="macro-row" style="--i: 1;">
                     <span class="macro-row__label">Carbs</span>
                     <div class="progress progress--lg" role="progressbar" aria-label="Carbohydrates progress"
                          th:attr="aria-valuenow=${pctCarbs}" aria-valuemin="0" aria-valuemax="100">
                         <div class="progress__fill progress__fill--carb" th:style="|width: ${pctCarbs}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <strong th:text="${totalCarbs}">0</strong>
+                        <strong th:text="${totalCarbs}" data-count-up>0</strong>
                         <span class="macro-row__goal"> / <span th:text="${goalCarbs}">250</span> g</span>
                     </span>
                 </div>
-                <div class="macro-row">
+                <div class="macro-row" style="--i: 2;">
                     <span class="macro-row__label">Fat</span>
                     <div class="progress progress--lg" role="progressbar" aria-label="Fat progress"
                          th:attr="aria-valuenow=${pctFat}" aria-valuemin="0" aria-valuemax="100">
                         <div class="progress__fill progress__fill--fat" th:style="|width: ${pctFat}%;|"></div>
                     </div>
                     <span class="macro-row__value">
-                        <strong th:text="${totalFat}">0</strong>
+                        <strong th:text="${totalFat}" data-count-up>0</strong>
                         <span class="macro-row__goal"> / <span th:text="${goalFat}">65</span> g</span>
                     </span>
                 </div>

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -40,7 +40,7 @@
         <section class="featured" th:if="${featured != null and !featured.isEmpty()}" aria-label="Featured this week">
             <h2 class="featured__title">Featured this week</h2>
             <div class="featured__strip">
-                <article class="featured-card" th:each="f : ${featured}">
+                <article class="featured-card" th:each="f, fIter : ${featured}" th:style="|--i: ${fIter.index};|">
                     <a th:href="|/recipes/${f.id}|" class="featured-card__link">
                         <div class="featured-card__cover">
                             <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}"
@@ -77,7 +77,7 @@
         </form>
 
         <div class="recipe-grid" th:if="${recipes != null and !recipes.isEmpty()}">
-            <article class="card recipe-card" th:each="r : ${recipes}">
+            <article class="card recipe-card" th:each="r, rIter : ${recipes}" th:style="|--i: ${rIter.index};|">
                 <a th:href="|/recipes/${r.id}|" class="recipe-card__link">
                     <div class="recipe-card__cover" th:classappend="${r.imageUrl == null} ? |recipe-card__cover--${r.coverTone}|">
                         <img th:if="${r.imageUrl != null}" th:src="${r.imageUrl}" th:alt="${r.title}"


### PR DESCRIPTION
## Summary
The "丝滑动效" pass. Four deliberate motion moves on the two highest-traffic surfaces (Dashboard, Recipes), all CSS + ~30 lines of vanilla JS, gated behind `prefers-reduced-motion`.

- **Stagger reveal.** New `@keyframes stagger-rise` (10px translate-up + opacity 0→1, 420ms, spring curve). `.recipe-card`, `.featured-card`, `.macro-row` all carry `--i` (Thymeleaf `iter.index` for the iterated grids; hardcoded 0/1/2 for the three macro rows). Animation delay = `calc(var(--i) * 60ms)`. The page composes itself row-by-row instead of slamming in at once.
- **Calorie ring fill.** `@property --ring-pct` is registered as a `<number>` with `initial-value: 0`, so the conic-gradient color-stop becomes a real interpolatable property. `.ring` adds `transition: --ring-pct 0.85s cubic-bezier(0.16, 1, 0.3, 1)`. The ring goes from empty to the actual percent on mount — the most visible motion moment of the app.
- **Count-up on Dashboard.** New `initCountUp()` in `app.js` (~30 lines): scans `[data-count-up]` elements, parses the rendered final value, tweens from 0 over 700ms with ease-out cubic. Preserves the existing integer / 1-decimal formatting from the server-side `.fmt()` helper. Applied to ring center (calories, %), and the three macro current-value `<strong>`s.
- **One-shot shimmer.** `.progress--lg::after` is a translucent white linear-gradient that slides across each bar once (`shimmer-once` 1.4s × iteration count 1, 0.9s delay so it lands after the bar fill + ring animation). Never loops; pure decoration that draws the eye to "today's progress".

### Reduced motion
All four wrapped in `@media (prefers-reduced-motion: no-preference)`. JS `initCountUp` early-returns when `matchMedia('(prefers-reduced-motion: reduce)').matches`. With reduced-motion on: layout renders instantly to final state, no jank, no fake-progress.

### Hover (skipped — already done)
Cards and buttons already use the `--ease-out` spring curve from earlier passes — no change needed for the "spring hover" bullet on the issue.

## Files
- `static/css/styles.css` — `@property --ring-pct`, `@keyframes stagger-rise / shimmer-once`, gated motion block.
- `static/js/app.js` — `initCountUp()` + wired into `DOMContentLoaded`.
- `subscriber/dashboard.html` — `data-count-up` on the four numeric values; `style="--i: 0/1/2"` on macro rows.
- `subscriber/recipes.html` — `iter.index` passed as `--i` on featured cards + recipe-grid cards.
- `CHANGELOG.md` — brief v0.6.11.

## Test plan
- [ ] CI green
- [ ] After deploy: open /dashboard with cookies cleared — see numbers tween up, ring fill, bars stagger in, then shimmer pass
- [ ] /recipes — featured strip cards rise in sequence; grid below staggers row-by-row
- [ ] Toggle macOS / iOS Reduce Motion → reload → all motion gone, layout snaps to final state
- [ ] No console errors

Closes #64