### PR TITLE
feat: layout pass — Goals chart, week nav, fav cards, auth toggle (v0.6.12)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.12] - 2026-05-02 — Layout pass: Goals chart promotion, week nav, profile fav cards, login toggle anchor (closes #66)
+
+### Changed
+- `.two-col--goals` now uses `grid-template-columns: 2fr 3fr` so the weekly chart card takes 60% of the row vs the form's 40%; on `<720px` the layout stacks chart-first.
+- New `weekly-head` block in the chart card with the week label (e.g. `May 4 – May 10, 2026`) and a compact `← / This week / →` nav. `GoalRoutes` accepts `?week=YYYY-MM-DD` and snaps any non-Monday to its Monday; `DiaryService` gains a `getWeeklySummary(userId, monday)` overload.
+- Profile favourites render as `.fav-card` rows with a 80×80 cover thumbnail (real Unsplash for seed recipes, emoji-on-tone fallback otherwise) plus title + difficulty + rating; "Not rated yet" replaces `★ 0.0` for unrated.
+- Login dark/light theme toggle moved out of `position:fixed` page chrome and into the auth card itself (top-right corner, pill outline) — reads as part of the form, not a stray dev button.
+
+---
+
 ## [v0.6.11] - 2026-05-02 — Motion pass: stagger reveal, ring fill, count-up, shimmer (closes #64)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
@@ -61,6 +61,15 @@ object DiaryService {
      */
     fun getWeeklySummary(userId: Int): List<Map<String, Any>> {
         val today = LocalDate.now(); val monday = today.minusDays(today.dayOfWeek.value.toLong() - 1)
+        return getWeeklySummary(userId, monday)
+    }
+
+    /**
+     * Mon–Sun calorie roll-up for the week starting at [monday]. Always returns
+     * 7 rows; days with no entries appear as 0. Used by the goals page when
+     * the marker scrolls back/forwards to inspect a different week.
+     */
+    fun getWeeklySummary(userId: Int, monday: LocalDate): List<Map<String, Any>> {
         return (0..6).map { offset ->
             val d = monday.plusDays(offset.toLong()); val summary = getDailySummary(userId, d)
             mapOf("date" to d, "dayName" to d.dayOfWeek.name.take(3).lowercase().replaceFirstChar { it.uppercase() }, "calories" to summary["calories"]!!)

--- a/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
@@ -12,12 +12,22 @@ import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.thymeleaf.*
 import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 fun Route.goalRoutes() {
     get("/goals") {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
+        val today = LocalDate.now()
+        val currentMonday = today.minusDays(today.dayOfWeek.value.toLong() - 1)
+        val weekParam = call.request.queryParameters["week"]
+        val weekStart: LocalDate = weekParam?.let {
+            try { LocalDate.parse(it) } catch (_: Exception) { currentMonday }
+        } ?: currentMonday
+        // Snap to Monday if the user passed any other day in the URL.
+        val monday = weekStart.minusDays(weekStart.dayOfWeek.value.toLong() - 1)
         val goals = GoalService.getGoals(session.userId)
-        val weekly = DiaryService.getWeeklySummary(session.userId)
+        val weekly = DiaryService.getWeeklySummary(session.userId, monday)
         val unread = MessageService.getUnreadCount(session.userId)
         val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
         val displayWeekly = weekly.map { w -> mapOf(
@@ -25,8 +35,17 @@ fun Route.goalRoutes() {
             "dayName" to w["dayName"],
             "calories" to (w["calories"] as BigDecimal).fmt(0)
         ) }
+        val labelFmt = DateTimeFormatter.ofPattern("MMM d")
+        val sunday = monday.plusDays(6)
+        val weekLabel = "${monday.format(labelFmt)} – ${sunday.format(labelFmt)}, ${monday.year}"
+        val prevWeek = monday.minusDays(7)
+        val nextWeek = monday.plusDays(7)
+        val isCurrentWeek = monday == currentMonday
         call.respond(ThymeleafContent("subscriber/goals", model(
-            "session" to session, "goals" to displayGoals, "weekly" to displayWeekly, "unreadMessages" to unread, "activePage" to "goals")))
+            "session" to session, "goals" to displayGoals, "weekly" to displayWeekly,
+            "weekLabel" to weekLabel, "prevWeek" to prevWeek, "nextWeek" to nextWeek,
+            "isCurrentWeek" to isCurrentWeek,
+            "unreadMessages" to unread, "activePage" to "goals")))
     }
 
     post("/goals") {

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -197,9 +197,15 @@ object RecipeService {
      */
     fun getUserFavourites(userId: Int): List<Map<String, Any?>> = transaction {
         (RecipeFavourites innerJoin Recipes).selectAll().where { RecipeFavourites.userId eq userId }.map { row ->
-            val rid = row[Recipes.id]; val ratings = RecipeRatings.selectAll().where { RecipeRatings.recipeId eq rid }.toList()
+            val rid = row[Recipes.id]
+            val title = row[Recipes.title]
+            val ratings = RecipeRatings.selectAll().where { RecipeRatings.recipeId eq rid }.toList()
             val avg = if (ratings.isNotEmpty()) ratings.map { it[RecipeRatings.rating] }.average() else 0.0
-            mapOf("id" to rid, "title" to row[Recipes.title], "difficulty" to row[Recipes.difficulty], "avgRating" to BigDecimal(avg).setScale(1, RoundingMode.HALF_UP))
+            mapOf("id" to rid, "title" to title, "difficulty" to row[Recipes.difficulty],
+                "avgRating" to BigDecimal(avg).setScale(1, RoundingMode.HALF_UP),
+                "reviewCount" to ratings.size,
+                "imageUrl" to row[Recipes.imageUrl],
+                "coverEmoji" to recipeCoverEmoji(title), "coverTone" to recipeCoverTone(title))
         }
     }
 }

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -423,6 +423,7 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow);
     border: none;
+    position: relative;
 }
 
 .auth-brand {
@@ -1434,7 +1435,134 @@ input::placeholder, textarea::placeholder {
     gap: 24px;
     margin-bottom: 24px;
 }
-.two-col--goals { align-items: start; }
+.two-col--goals {
+    align-items: start;
+    grid-template-columns: 2fr 3fr;
+}
+@media (max-width: 720px) {
+    .two-col--goals { grid-template-columns: 1fr; }
+    .two-col--goals > section:nth-child(2) { order: -1; }
+}
+
+.weekly-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-bottom: 14px;
+}
+.weekly-head__title { margin: 0; }
+.weekly-head__label {
+    margin: 4px 0 0;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+    font-weight: 500;
+}
+.date-nav--compact .btn--small {
+    padding: 4px 12px;
+    font-size: var(--text-sm);
+    min-width: auto;
+}
+.date-nav--compact .is-current {
+    background: var(--color-mint-bg);
+    color: var(--color-sage-deep);
+    border-color: transparent;
+}
+
+.fav-recipe-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+}
+.fav-card {
+    background: var(--color-surface-warm);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    transition: transform var(--dur) var(--ease-out), box-shadow var(--dur) var(--ease-out);
+}
+.fav-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-sm);
+}
+.fav-card__link {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    gap: 14px;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
+    padding: 0;
+}
+.fav-card__link:hover { text-decoration: none; }
+.fav-card__cover {
+    width: 80px;
+    height: 80px;
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft));
+}
+.fav-card__cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.fav-card__cover-fallback {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 30px;
+}
+.fav-card__body {
+    padding: 6px 14px 6px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.fav-card__title {
+    font-weight: 700;
+    color: var(--text-strong);
+    font-size: var(--text-base);
+    line-height: 1.25;
+}
+.fav-card__meta {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--text-soft);
+    font-weight: 600;
+}
+.fav-card__unrated {
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 500;
+    font-style: italic;
+}
+
+.auth-theme-toggle {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    background: transparent;
+    color: var(--text-soft);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-pill);
+    padding: 6px 14px;
+    font: inherit;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
+}
+.auth-theme-toggle:hover {
+    background: var(--color-surface-warm);
+    color: var(--text-strong);
+    border-color: var(--color-border-strong);
+}
 
 .section-title {
     margin: 0 0 14px;

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -7,11 +7,9 @@
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="auth-body">
-<button type="button" class="sidebar__theme js-theme-toggle"
-        aria-label="Toggle theme"
-        style="position:fixed;top:1rem;right:1rem;background:var(--color-surface);color:var(--color-muted);border:1px solid var(--color-border);box-shadow:var(--shadow-sm);">Toggle theme</button>
 <div class="auth-shell">
     <div class="auth-card card">
+        <button type="button" class="auth-theme-toggle js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <div class="auth-brand">
             <span class="auth-logo" aria-hidden="true">🥗</span>
             <h1 class="auth-title">Good Food</h1>

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -66,8 +66,19 @@
             </section>
 
             <section class="card">
-                <h2 class="section-title">This week (calories)</h2>
-                <p class="chart-caption">Each bar shows total kcal logged that day.</p>
+                <header class="weekly-head">
+                    <div>
+                        <h2 class="section-title weekly-head__title">Calories this week</h2>
+                        <p class="weekly-head__label" th:text="${weekLabel}">May 4 – May 10, 2026</p>
+                    </div>
+                    <div class="date-nav date-nav--compact">
+                        <a class="btn btn--ghost btn--small" th:href="|/goals?week=${prevWeek}|" aria-label="Previous week">←</a>
+                        <a class="btn btn--ghost btn--small"
+                           th:classappend="${isCurrentWeek} ? ' is-current'"
+                           th:href="'/goals'">This week</a>
+                        <a class="btn btn--ghost btn--small" th:href="|/goals?week=${nextWeek}|" aria-label="Next week">→</a>
+                    </div>
+                </header>
                 <div class="weekly-chart" th:if="${weekly != null and !weekly.isEmpty()}">
                     <div class="weekly-chart__row" th:each="w : ${weekly}">
                         <span class="weekly-chart__label" th:text="${w.dayName}">Mon</span>

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -61,13 +61,24 @@
             <section class="card">
                 <h2 class="section-title">Favourite recipes</h2>
                 <ul class="fav-recipe-list" th:if="${favourites != null and !favourites.isEmpty()}">
-                    <li th:each="f : ${favourites}">
-                        <a th:href="|/recipes/${f.id}|" class="fav-recipe-list__link">
-                            <span th:text="${f.title}">Recipe</span>
-                            <span class="fav-recipe-list__meta">
-                                <span th:text="${f.difficulty}">easy</span>
-                                · ★ <span th:text="${f.avgRating}">0</span>
-                            </span>
+                    <li th:each="f : ${favourites}" class="fav-card">
+                        <a th:href="|/recipes/${f.id}|" class="fav-card__link">
+                            <div class="fav-card__cover">
+                                <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}"
+                                     width="160" height="160" loading="lazy"/>
+                                <div th:if="${f.imageUrl == null}" class="fav-card__cover-fallback"
+                                     th:classappend="|recipe-card__cover--${f.coverTone}|">
+                                    <span th:text="${f.coverEmoji}">🍽️</span>
+                                </div>
+                            </div>
+                            <div class="fav-card__body">
+                                <span class="fav-card__title" th:text="${f.title}">Recipe</span>
+                                <span class="fav-card__meta">
+                                    <span th:text="${f.difficulty}">easy</span>
+                                    <span th:if="${f.reviewCount > 0}"> · ★ <span th:text="${f.avgRating}">0</span></span>
+                                    <span th:if="${f.reviewCount == 0}" class="fav-card__unrated"> · Not rated yet</span>
+                                </span>
+                            </div>
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
## Summary
Four layout-level moves from the /critique pass.

- **Goals chart promoted to hero.** `.two-col--goals` now `grid-template-columns: 2fr 3fr` so the weekly chart card takes 60% of the row vs the form's 40%; on `<720px` the layout stacks chart-first. The chart is the only "alive" thing on that page — it should lead.
- **Weekly chart accepts `?week=`.** New `DiaryService.getWeeklySummary(userId, monday)` overload (the old no-arg version delegates). `GoalRoutes` parses the query param, snaps any non-Monday to its Monday, computes prev/next/current Monday, passes a human label like `May 4 – May 10, 2026`. New `.weekly-head` row in the chart card with `← / This week / →` buttons; the "This week" pill carries an `is-current` accent (mint background) when the user is on the current week.
- **Profile favourites cards.** `RecipeService.getUserFavourites` now includes `imageUrl`, `coverEmoji`, `coverTone`, `reviewCount`. Template renders each as a `.fav-card` row with an 80×80 cover thumbnail (real Unsplash for seed recipes, emoji-on-tone fallback for user-uploaded), plus title + difficulty + rating; "Not rated yet" replaces `★ 0.0` for unrated.
- **Login theme toggle anchored.** Moved from a `position: fixed` top-right floater with inline styles into the auth card's top-right corner with a new `.auth-theme-toggle` pill style. Reads as part of the form, not stray dev chrome. `.auth-card { position: relative }` so the absolute toggle anchors to it.

## Files
- `DiaryService.kt` — `getWeeklySummary(userId, monday)` overload.
- `GoalRoutes.kt` — `?week=` parsing, week label, prev/next computation.
- `RecipeService.kt` — favourites map gains `imageUrl` / `coverEmoji` / `coverTone` / `reviewCount`.
- `subscriber/goals.html` — `.weekly-head` block + week nav buttons.
- `subscriber/profile.html` — `.fav-card` markup + thumbnail.
- `auth/login.html` — toggle moved into card.
- `static/css/styles.css` — `.two-col--goals` 2fr 3fr, `.weekly-head*`, `.date-nav--compact .is-current`, `.fav-card*`, `.auth-theme-toggle`, `.auth-card { position: relative }`.
- `CHANGELOG.md` — brief v0.6.12.

## Test plan
- [ ] CI green
- [ ] /goals — chart card visibly wider than form; ←/→ buttons cycle weeks; URL updates with `?week=YYYY-MM-DD`
- [ ] /profile — favourites show with cover thumbnails matching the recipe grid
- [ ] /login — dark mode toggle sits inside the auth card top-right; Cmd+I toggle still works (theme persists)
- [ ] 720px breakpoint: Goals layout stacks chart-first

Closes #66