### PR TITLE
feat: strategy pass — recipe→author chat, mint, reduced-motion (v0.6.13)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.13] - 2026-05-02 — Strategy pass: recipe→author chat, mint earns its keep, reduced-motion guard (closes #68)
+
+### Added
+- Recipe detail now shows a mint-tinted "Message *Dr. Sarah Williams* →" pill under the rating row, linking to `/messages/<authorId>`. Hidden when the viewing user is the author. `RecipeService.getRecipeDetail` returns `authorId` + `authorName` so the template doesn't have to look them up.
+- Mint accent now reads as a system, not an orphan token: Featured strip underline (v0.6.7) + Goals "This week" pill (v0.6.12) + Dashboard empty-day CTA gradient (v0.6.9) + new recipe→author chat button.
+
+### Fixed
+- Universal `prefers-reduced-motion: reduce` block clamps all animations / transitions to 0.01ms and disables continuous loops (login background blobs, progress-bar shimmer). Backstop to the per-feature gating already in place since v0.6.11.
+
+---
+
 ## [v0.6.12] - 2026-05-02 — Layout pass: Goals chart promotion, week nav, profile fav cards, login toggle anchor (closes #66)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -121,6 +121,9 @@ object RecipeService {
      */
     fun getRecipeDetail(recipeId: Int): Map<String, Any?>? = transaction {
         val recipe = Recipes.selectAll().where { Recipes.id eq recipeId }.singleOrNull() ?: return@transaction null
+        val authorRow = Users.selectAll().where { Users.id eq recipe[Recipes.createdBy] }.singleOrNull()
+        val authorId = recipe[Recipes.createdBy]
+        val authorName = authorRow?.get(Users.fullName) ?: "the author"
         val ingredients = RecipeIngredients.selectAll().where { RecipeIngredients.recipeId eq recipeId }.map { row ->
             mapOf("name" to row[RecipeIngredients.ingredientName], "quantity" to row[RecipeIngredients.quantity],
                 "unit" to row[RecipeIngredients.unit], "foodItemId" to row[RecipeIngredients.foodItemId])
@@ -148,6 +151,7 @@ object RecipeService {
             "prepTime" to recipe[Recipes.prepTimeMinutes], "cookTime" to recipe[Recipes.cookTimeMinutes],
             "totalTime" to (recipe[Recipes.prepTimeMinutes] + recipe[Recipes.cookTimeMinutes]),
             "servings" to recipe[Recipes.servings], "difficulty" to recipe[Recipes.difficulty],
+            "authorId" to authorId, "authorName" to authorName,
             "ingredients" to ingredients, "steps" to steps, "ratings" to ratings,
             "avgRating" to BigDecimal(avgRating).setScale(1, RoundingMode.HALF_UP), "reviewCount" to ratings.size,
             "calPerServing" to totalCal.divide(servings, 0, RoundingMode.HALF_UP),

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1564,6 +1564,62 @@ input::placeholder, textarea::placeholder {
     border-color: var(--color-border-strong);
 }
 
+.recipe-hero__chat {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 14px;
+    padding: 10px 16px;
+    background: var(--color-mint-bg);
+    color: var(--color-sage-deep);
+    border-radius: var(--radius-pill);
+    text-decoration: none;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    border: 1px solid transparent;
+    transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease-out);
+}
+.recipe-hero__chat:hover {
+    background: var(--color-mint);
+    border-color: var(--color-sage);
+    color: var(--color-sage-deep);
+    text-decoration: none;
+    transform: translateX(2px);
+}
+.recipe-hero__chat-label { color: var(--color-sage); font-weight: 500; }
+.recipe-hero__chat-name { color: var(--color-sage-deep); font-weight: 700; }
+.recipe-hero__chat-arrow {
+    font-weight: 700;
+    transition: transform var(--dur-fast) var(--ease-out);
+}
+.recipe-hero__chat:hover .recipe-hero__chat-arrow { transform: translateX(3px); }
+
+/* ============================================================
+   Reduced motion — universal opt-out.
+   Belt-and-suspenders to the per-feature gating: any animation /
+   transition still slips through gets clamped to ~instant. Continuous
+   loops (login background blobs, conv-active accent, etc.) are killed
+   outright.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+    .auth-body::before,
+    .auth-body::after {
+        animation: none !important;
+    }
+    .progress--lg::after {
+        animation: none !important;
+        opacity: 0;
+    }
+}
+
 .section-title {
     margin: 0 0 14px;
     font-size: var(--text-lg);

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -49,6 +49,13 @@
                     <span th:text="${recipe.avgRating}">0</span> / 5
                     (<span th:text="${recipe.reviewCount}">0</span> reviews)
                 </div>
+                <a th:if="${recipe.authorId != null and recipe.authorId != session.userId}"
+                   th:href="|/messages/${recipe.authorId}|"
+                   class="recipe-hero__chat">
+                    <span class="recipe-hero__chat-label">Message</span>
+                    <span class="recipe-hero__chat-name" th:text="${recipe.authorName}">Author</span>
+                    <span class="recipe-hero__chat-arrow" aria-hidden="true">→</span>
+                </a>
             </div>
             <form th:action="|/recipes/${recipe.id}/favourite|" method="post" class="fav-form">
                 <button type="submit" class="btn btn--ghost fav-btn" th:classappend="${isFavourite} ? ' fav-btn--on' : ''">


### PR DESCRIPTION
## Summary
Final batch of the 21-item roadmap. Three strategic moves.

- **Recipe → author chat affordance.** `RecipeService.getRecipeDetail` now returns `authorId` + `authorName` (looked up via `Users` join). Recipe detail template shows a mint-tinted `Message <Dr. Sarah Williams> →` pill under the rating row when the viewer isn't the author themselves. Closes the open loop between Recipes (where Sarah is the author) and Messages (which previously had no inbound link from anywhere).
- **Mint accent earns its keep.** `--color-mint*` was introduced in v0.6.7 with a single use (Featured strip underline). v0.6.9 added it to the Dashboard empty-day CTA gradient. v0.6.12 added it to the Goals "This week" pill. This PR adds it to the new recipe→author chat button. Four uses across three pages — reads as system, not orphan.
- **`prefers-reduced-motion` universal guard.** Per-feature gating was added in v0.6.11 for the new motion. Older animations (`.auth-body` blob drift, `.main` fade-up entry, hover transforms, etc.) were not yet audited. New universal `@media (prefers-reduced-motion: reduce)` block clamps `animation-duration` / `transition-duration` to 0.01ms and disables continuous loops outright. Backstop — anything that slips through the per-feature gates also gets caught here.

## Files
- `RecipeService.kt` — `authorId` + `authorName` in the `getRecipeDetail` map.
- `subscriber/recipe-detail.html` — `<a class="recipe-hero__chat">` block, hidden when `authorId == session.userId`.
- `static/css/styles.css` — `.recipe-hero__chat*` block + universal reduced-motion `@media` block at the end.
- `CHANGELOG.md` — brief v0.6.13.

## Test plan
- [ ] CI green
- [ ] /recipes/1 (Grilled Chicken Salad, author = Sarah) shows the mint pill; clicking goes to /messages/<sarahId>
- [ ] Sarah viewing her own recipe doesn't see the pill (`authorId == session.userId` gate)
- [ ] OS-level Reduce Motion → reload any page → all stagger / fade / shimmer disabled, blob drift on login still
- [ ] Mint visible in 4 places: Featured underline, Goals "This week" pill, Dashboard CTA, new recipe→author button

Closes #68