### PR TITLE
feat: goals page stacks vertically, macro inputs grid (v0.6.15)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.15] - 2026-05-03 — Goals page stacks vertically: targets on top, weekly chart full-width below (closes #77)
+
+### Changed
+- `.two-col--goals` is now a single full-width column at all breakpoints. The previous `2fr 3fr` split left a tall narrow form on the left with dead space below and squeezed the weekly bars into 60% of the row.
+- Inside the Daily targets card, the 5 macro inputs (calories / protein / carbs / fat / fiber) now lay out as a horizontal grid (`.goals-form__fields`): 5-col on desktop, 3-col `<960px`, 2-col `<640px`, 1-col `<420px`. Form card stays short instead of stretching down by 5 stacked fields.
+- Save button (`.goals-form__submit`) aligns to start so it doesn't stretch full-width across the now-wide form card.
+- Dropped the obsolete `order: -1` mobile swap — natural document order (form first, chart below) is now what we want at every viewport.
+
+---
+
 ## [v0.6.14] - 2026-05-02 — Dark-mode pass: brand tones flip, scrim + emoji halo tokenized (closes #70)
 
 ### Fixed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1551,13 +1551,29 @@ input::placeholder, textarea::placeholder {
     gap: 24px;
     margin-bottom: 24px;
 }
+/* Goals page stacks vertically: daily targets card on top, weekly chart card below.
+   The 5 macro inputs lay out horizontally inside the form (.goals-form__fields)
+   so the top card stays short and the chart below has full width to breathe. */
 .two-col--goals {
-    align-items: start;
-    grid-template-columns: 2fr 3fr;
+    grid-template-columns: 1fr;
 }
-@media (max-width: 720px) {
-    .two-col--goals { grid-template-columns: 1fr; }
-    .two-col--goals > section:nth-child(2) { order: -1; }
+
+.goals-form__fields {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 16px;
+}
+@media (max-width: 960px) {
+    .goals-form__fields { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 640px) {
+    .goals-form__fields { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 420px) {
+    .goals-form__fields { grid-template-columns: 1fr; }
+}
+.goals-form__submit {
+    align-self: start;
 }
 
 .weekly-head {

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -41,27 +41,29 @@
             <section class="card">
                 <h2 class="section-title">Daily targets</h2>
                 <form class="form-stack" th:action="'/goals'" method="post">
-                    <label class="field">
-                        <span class="field__label">Calories (kcal)</span>
-                        <input type="number" name="calories" step="1" min="0" th:value="${goals['calories']}"/>
-                    </label>
-                    <label class="field">
-                        <span class="field__label">Protein (g)</span>
-                        <input type="number" name="protein" step="0.1" min="0" th:value="${goals['protein']}"/>
-                    </label>
-                    <label class="field">
-                        <span class="field__label">Carbs (g)</span>
-                        <input type="number" name="carbs" step="0.1" min="0" th:value="${goals['carbs']}"/>
-                    </label>
-                    <label class="field">
-                        <span class="field__label">Fat (g)</span>
-                        <input type="number" name="fat" step="0.1" min="0" th:value="${goals['fat']}"/>
-                    </label>
-                    <label class="field">
-                        <span class="field__label">Fiber (g)</span>
-                        <input type="number" name="fiber" step="0.1" min="0" th:value="${goals['fiber']}"/>
-                    </label>
-                    <button type="submit" class="btn btn--primary">Save goals</button>
+                    <div class="goals-form__fields">
+                        <label class="field">
+                            <span class="field__label">Calories (kcal)</span>
+                            <input type="number" name="calories" step="1" min="0" th:value="${goals['calories']}"/>
+                        </label>
+                        <label class="field">
+                            <span class="field__label">Protein (g)</span>
+                            <input type="number" name="protein" step="0.1" min="0" th:value="${goals['protein']}"/>
+                        </label>
+                        <label class="field">
+                            <span class="field__label">Carbs (g)</span>
+                            <input type="number" name="carbs" step="0.1" min="0" th:value="${goals['carbs']}"/>
+                        </label>
+                        <label class="field">
+                            <span class="field__label">Fat (g)</span>
+                            <input type="number" name="fat" step="0.1" min="0" th:value="${goals['fat']}"/>
+                        </label>
+                        <label class="field">
+                            <span class="field__label">Fiber (g)</span>
+                            <input type="number" name="fiber" step="0.1" min="0" th:value="${goals['fiber']}"/>
+                        </label>
+                    </div>
+                    <button type="submit" class="btn btn--primary goals-form__submit">Save goals</button>
                 </form>
             </section>
 


### PR DESCRIPTION
Closes #77.

## Summary
- Goals page is now a vertical stack: **Daily targets card on top**, **Calories this week card below** (full-width).
- The 5 macro inputs lay out horizontally inside the form card (5-col → 3 → 2 → 1 at 960 / 640 / 420 px breakpoints) so the top card stays short instead of stretching down 5 stacked fields.
- Save button aligns to start, doesn't stretch across the now full-width form.

## Test plan
- [ ] Visit `/goals` on a wide viewport — Daily targets card spans full width with the 5 macro inputs in a single row, Save button below-left, weekly chart card below the form spanning full width.
- [ ] Resize to ~900px — macro inputs reflow to 3 columns.
- [ ] Resize to ~600px — macro inputs reflow to 2 columns.
- [ ] Resize to ~400px — macro inputs stack to 1 column.
- [ ] Submit the form with new values — values save and the page re-renders with form on top.
- [ ] Verify in dark mode that the new layout still reads correctly.