### PR TITLE
feat: weekly calorie chart redesign — substantive bars + state-aware rows (v0.6.16)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.16] - 2026-05-03 — Weekly calorie chart: substantive bars with empty / over / today states (closes #79)
+
+### Changed
+- The `<progress>`-based weekly chart on `/goals` was anemic 6px line art that didn't distinguish "logged nothing" from "logged a tiny meal" or flag over-goal days. Replaced with a div-based 12px pill bar (`.weekly-chart__track` + `.weekly-chart__fill`) carrying four meaningful row states.
+- `GoalRoutes.kt` now enriches each weekly row with `pct` (capped 0–100), `rowClass` (a space-prefixed string of `--empty` / `--over` / `--today` modifiers), and uses the calorie goal as the bar's natural max instead of a hardcoded 3000.
+- **Default**: sage-deep → sage gradient fill, scaled to `(calories / goalCalories) * 100` (capped at 100%).
+- **Empty** (`0 kcal`): track switches to a 1px dashed border so "no data" is visually distinct from "almost-empty"; calorie number softens to `--color-faint`.
+- **Over goal** (>110% of target — 10% buffer so right-around-goal stays sage): fill flips to a clay/warn gradient.
+- **Today**: row gets a soft mint pill background, day name promoted to sage-deep / weight 700 so users can see where they are in the week at a glance.
+- Calorie numbers now use `var(--font-mono)` + `font-variant-numeric: tabular-nums` so the column lines up vertically; small uppercase `kcal` unit label sits next to each value.
+- New `bar-grow` keyframe (`scaleX(0) → scaleX(1)`, `--ease-out`, 0.7s, staggered `70ms × var(--i)` with a 0.2s page settle) gated behind `prefers-reduced-motion: no-preference`.
+
+---
+
 ## [v0.6.15] - 2026-05-03 — Goals page stacks vertically: targets on top, weekly chart full-width below (closes #77)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/goals/GoalRoutes.kt
@@ -30,11 +30,33 @@ fun Route.goalRoutes() {
         val weekly = DiaryService.getWeeklySummary(session.userId, monday)
         val unread = MessageService.getUnreadCount(session.userId)
         val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
-        val displayWeekly = weekly.map { w -> mapOf(
-            "date" to w["date"],
-            "dayName" to w["dayName"],
-            "calories" to (w["calories"] as BigDecimal).fmt(0)
-        ) }
+        // Calorie goal drives the bar scale. If the user hasn't set one, every
+        // bar reads as "empty" — pct stays 0 and the dashed empty track shows.
+        val goalCals: Double = goals?.get("calories")?.toDouble() ?: 0.0
+        val displayWeekly = weekly.map { w ->
+            val calsRaw = w["calories"] as BigDecimal
+            val cals = calsRaw.toDouble()
+            val rowDate = w["date"] as LocalDate
+            val pct: Int = if (goalCals > 0) ((cals / goalCals) * 100).coerceAtMost(100.0).toInt() else 0
+            // 10% buffer so "right around goal" stays sage-green; only meaningfully-over days flip to clay.
+            val isOver = goalCals > 0 && cals > goalCals * 1.10
+            val isEmpty = cals == 0.0
+            val isToday = rowDate == today
+            val rowClass = buildString {
+                when {
+                    isEmpty -> append(" weekly-chart__row--empty")
+                    isOver  -> append(" weekly-chart__row--over")
+                }
+                if (isToday) append(" weekly-chart__row--today")
+            }
+            mapOf(
+                "date" to rowDate,
+                "dayName" to (w["dayName"] ?: ""),
+                "calories" to calsRaw.fmt(0),
+                "pct" to pct,
+                "rowClass" to rowClass
+            )
+        }
         val labelFmt = DateTimeFormatter.ofPattern("MMM d")
         val sunday = monday.plusDays(6)
         val weekLabel = "${monday.format(labelFmt)} – ${sunday.format(labelFmt)}, ${monday.year}"

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1822,28 +1822,85 @@ input::placeholder, textarea::placeholder {
     color: var(--text-soft);
     margin: 0 0 14px;
 }
+/* Calorie weekly chart — substantive 12px-tall pill bars with gradient fill,
+   tabular-mono numbers, and four meaningful row states:
+   default (sage gradient) / --over (clay/warn) / --empty (dashed track) /
+   --today (mint pill bg). */
+.weekly-chart {
+    margin: 4px -8px 0;  /* row hover/today bg can bleed slightly past card padding */
+}
 .weekly-chart__row {
     display: grid;
-    grid-template-columns: 56px 1fr 56px;
+    grid-template-columns: 56px 1fr 96px;
     align-items: center;
-    gap: 12px;
-    margin-bottom: 8px;
+    gap: 16px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    transition: background var(--dur-fast) var(--ease);
 }
-.weekly-chart__label {
+.weekly-chart__row:hover { background: var(--color-surface-warm); }
+.weekly-chart__row--today,
+.weekly-chart__row--today:hover { background: var(--color-mint-bg); }
+
+.weekly-chart__day {
     font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-soft);
+    letter-spacing: var(--tracking-snug);
 }
-.weekly-chart__bar {
-    width: 100%;
-    height: 6px;
-    accent-color: var(--color-primary);
+.weekly-chart__row--today .weekly-chart__day {
+    color: var(--color-sage-deep);
+    font-weight: 700;
 }
+
+.weekly-chart__track {
+    position: relative;
+    height: 12px;
+    background: var(--color-progress-track);
+    border-radius: var(--radius-pill);
+    overflow: hidden;
+}
+.weekly-chart__row--empty .weekly-chart__track {
+    background: transparent;
+    border: 1px dashed var(--color-border);
+    height: 10px;
+}
+.weekly-chart__fill {
+    display: block;
+    height: 100%;
+    width: var(--pct, 0%);
+    background: linear-gradient(90deg, var(--color-sage-deep), var(--color-sage));
+    border-radius: inherit;
+    transform-origin: left center;
+}
+.weekly-chart__row--over .weekly-chart__fill {
+    background: linear-gradient(90deg, var(--color-clay), var(--color-warn));
+}
+
 .weekly-chart__val {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: 4px;
     font-size: var(--text-sm);
+    color: var(--text-strong);
+    font-weight: 600;
+}
+.weekly-chart__num {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.01em;
+}
+.weekly-chart__unit {
+    font-size: 11px;
     color: var(--text-soft);
-    text-align: right;
     font-weight: 500;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+}
+.weekly-chart__row--empty .weekly-chart__num,
+.weekly-chart__row--empty .weekly-chart__unit {
+    color: var(--color-faint);
 }
 
 /* ============================================================
@@ -2306,6 +2363,11 @@ input::placeholder, textarea::placeholder {
     100% { transform: translateX(220%); }
 }
 
+@keyframes bar-grow {
+    from { transform: scaleX(0); }
+    to   { transform: scaleX(1); }
+}
+
 /* @property lets the conic-gradient stop position animate as a real number,
    not as a string interpolation between gradient images. Without it,
    the ring would snap rather than fill smoothly. */
@@ -2326,6 +2388,12 @@ input::placeholder, textarea::placeholder {
         opacity: 0;
         animation: stagger-rise 0.42s var(--ease-out) both;
         animation-delay: calc(var(--i, 0) * 60ms);
+    }
+
+    .weekly-chart__fill {
+        animation: bar-grow 0.7s var(--ease-out) both;
+        animation-delay: calc(0.2s + var(--i, 0) * 70ms);
+        transform: scaleX(0);
     }
 
     .progress--lg {

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -82,10 +82,19 @@
                     </div>
                 </header>
                 <div class="weekly-chart" th:if="${weekly != null and !weekly.isEmpty()}">
-                    <div class="weekly-chart__row" th:each="w : ${weekly}">
-                        <span class="weekly-chart__label" th:text="${w.dayName}">Mon</span>
-                        <progress class="weekly-chart__bar" th:value="${w.calories}" max="3000"></progress>
-                        <span class="weekly-chart__val" th:text="${w.calories}">0</span>
+                    <div class="weekly-chart__row"
+                         th:each="w, iter : ${weekly}"
+                         th:classappend="${w.rowClass}"
+                         th:style="|--pct:${w.pct}%; --i:${iter.index}|">
+                        <span class="weekly-chart__day" th:text="${w.dayName}">Mon</span>
+                        <div class="weekly-chart__track" role="img"
+                             th:attr="aria-label=|${w.dayName}: ${w.calories} kcal|">
+                            <span class="weekly-chart__fill" aria-hidden="true"></span>
+                        </div>
+                        <span class="weekly-chart__val">
+                            <span class="weekly-chart__num" th:text="${w.calories}">0</span>
+                            <span class="weekly-chart__unit">kcal</span>
+                        </span>
                     </div>
                 </div>
                 <p class="empty-hint" th:if="${weekly == null or weekly.isEmpty()}">Quiet week so far — log a meal to see progress.</p>


### PR DESCRIPTION
Closes #79.

## Summary
- Replaced the anemic `<progress>`-based 6px line on `/goals` with a 12px pill bar that has four meaningful row states: **default** (sage gradient), **--over** (clay/warn gradient when calories > 110% of goal), **--empty** (dashed transparent track + faint number for `0 kcal` days), **--today** (mint pill row bg + sage-deep day name).
- `GoalRoutes.kt` now uses the user's actual calorie goal as the bar max (not hardcoded `3000`), passes `pct` and a precomputed `rowClass` per row.
- Calorie numbers switched to `var(--font-mono)` + `tabular-nums` so they line up vertically; small uppercase `kcal` unit label.
- New `bar-grow` keyframe (scaleX 0→1, 0.7s, staggered `70ms × var(--i)` with a 0.2s page-settle delay) gated behind `prefers-reduced-motion: no-preference`.

## Design notes
- 10% buffer on the over-goal threshold so "right around goal" stays sage instead of punitively flipping to warning.
- Today's row only highlights when the displayed week contains today — past/future weeks render without the mint highlight, which is the right behavior.
- Empty-state track is a dashed border on transparent so "logged nothing" reads visually distinct from "logged 50 kcal," not the same gray rule.
- `box-shadow` / drop-shadow tokenization from v0.6.14 means the new bar reads correctly in dark mode without extra work.

## Test plan
- [ ] Visit `/goals` on a week with mixed data — bars should fill in left-to-right with a 70ms stagger.
- [ ] A day above 110% of the calorie goal should show a clay-tinted bar.
- [ ] A day with `0 kcal` should show a dashed transparent track and a faint `0 kcal` label.
- [ ] Today's row (when viewing the current week) should have a mint background pill and a darker, bolder day name.
- [ ] Navigate to a past or future week — no `--today` highlight should appear.
- [ ] Toggle `prefers-reduced-motion: reduce` (DevTools → Rendering) — bars should appear instantly without the grow animation.
- [ ] Verify in dark mode — gradient fills, dashed empty track, and mint pill all read correctly.
- [ ] Calorie numbers in the right column line up vertically (tabular-nums).