### PR TITLE
fix: sidebar sticks to viewport on long pages (v0.6.17)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.17] - 2026-05-03 — Sidebar sticks to the viewport on long pages (closes #81)
+
+### Changed
+- `.sidebar` is now `position: sticky; top: 0; height: 100vh` on desktop so long pages (recipes, diary) only scroll the main column — the nav stays pinned. `align-self: flex-start` keeps the flex parent from stretching the sidebar to match `.main`'s height, and `overflow-y: auto` lets unusually short viewports scroll within the sidebar instead of clipping the logout button.
+- The `≤840px` mobile drawer continues to use `position: fixed` (its own media-query rule wins), so no regression for the slide-in mobile menu.
+
+---
+
 ## [v0.6.16] - 2026-05-03 — Weekly calorie chart: substantive bars with empty / over / today states (closes #79)
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -633,6 +633,14 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 .sidebar {
     width: var(--sidebar-w);
     flex-shrink: 0;
+    /* Pin the nav to the viewport so long pages (recipes, diary) only scroll
+       the main column. align-self overrides the flex parent's default stretch
+       so the sidebar honors its own height instead of matching .main. */
+    align-self: flex-start;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
     background: var(--sidebar-bg);
     color: var(--sidebar-text);
     display: flex;


### PR DESCRIPTION
Closes #81.

## Summary
- `.sidebar` is now `position: sticky; top: 0; height: 100vh` on desktop, so long pages (recipes, diary) only scroll `.main` while the nav stays pinned.
- `align-self: flex-start` overrides the flex parent's default stretch (which is what was making sticky a no-op — the sidebar's height was already matching `.main`'s height, leaving nothing to stick to).
- `overflow-y: auto` is a defensive guard so unusually short viewports scroll within the sidebar instead of clipping logout / theme buttons.
- Mobile drawer (`≤840px`) keeps `position: fixed` via its existing media query, so the slide-in menu behavior is unchanged.

## Test plan
- [ ] Visit `/recipes` on desktop — scroll the page; the sidebar should stay pinned to the left, only the recipe grid scrolls.
- [ ] Same on `/diary`, `/goals`, `/messages`, `/profile` — sidebar pinned everywhere.
- [ ] Resize to ≤840px — sidebar disappears (drawer hidden behind hamburger), open drawer, drawer behaves exactly as before.
- [ ] Shrink viewport to ~500px tall (DevTools) — sidebar's own scrollbar appears, all 6 nav links + theme + logout still reachable.
- [ ] Verify in dark mode and during scroll — no jumping or repaint glitches.