### PR TITLE
feat: rebrand Good Food → Sage, salad emoji → SVG sage-leaf (v0.6.18)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -1,6 +1,18 @@
-# Changelog - Good Food & Healthy Eating
+# Changelog - Sage — Healthy Eating
 
 All notable changes to this project will be documented in this file.
+
+---
+
+## [v0.6.18] - 2026-05-03 — Rebrand: Good Food → Sage, salad emoji → SVG sage-leaf mark (closes #83)
+
+### Changed
+- Product name renamed from "Good Food" to **Sage** across every user-facing string: 11 page `<title>`s, sidebar brand text in 8 templates, the auth login title. Rationale: the brand color is already `--color-sage-deep / --color-sage / --color-sage-bg` so the name and visual identity collapse into one cohesive thing; "sage" is a culinary herb (food-coded) and means "wise" (fits the "make smarter food choices" positioning); one syllable, real word, premium minimal feel.
+- Logo `🥗` salad emoji replaced with an inline-SVG sage-leaf mark — a single confident curve plus midrib stroke, `stroke="currentColor"` so it inherits the brand-disc foreground color and flips correctly in dark mode. 18px in the 32px sidebar disc, 26px in the 48px auth-page disc.
+- The professional sidebar's `📋` clipboard emoji is also replaced with the same Sage leaf so the brand mark is consistent across consumer + practitioner surfaces; "Pro portal" is kept as a contextual subtitle so practitioners still know which mode they're in.
+- `.auth-logo` switched from text-centering (`line-height: 48px; text-align: center; font-size: 22px`) to flex-centering (`inline-flex` + `align-items: center` + `justify-content: center`) so the SVG centers cleanly without leftover text-rendering metrics.
+- File-header doc comments in `styles.css`, `app.js`, and `UserService.kt` updated for consistency. `README.md` and the CHANGELOG title line updated to the new brand.
+- Kotlin package `com.goodfood.*` is unchanged — this is a brand refresh, not an architectural refactor.
 
 ---
 

--- a/2850final project/src/main/kotlin/com/goodfood/auth/UserService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/auth/UserService.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
 
 /**
- * Authentication and account-management for the Good Food app.
+ * Authentication and account-management for the Sage app.
  *
  * Owns the password lifecycle (BCrypt hash on write, verify on login) and the
  * uniqueness rule on `email`. Routes interact with this object only — they

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 /* ============================================================
-   Good Food — warm wellness redesign (v0.6.0)
+   Sage — warm wellness redesign (v0.6.0)
 
    The v0.5.0 visual system was a disciplined research-journal
    pastiche but read clinically for a consumer wellness product
@@ -548,15 +548,14 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 }
 
 .auth-logo {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 48px;
     height: 48px;
     border-radius: var(--radius-pill);
     background: var(--color-primary);
     color: var(--color-primary-on);
-    line-height: 48px;
-    text-align: center;
-    font-size: 22px;
     margin-bottom: 16px;
     box-shadow: var(--shadow-sm);
 }

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -1,5 +1,5 @@
 /*
- * Good Food — front-end glue (auth tabs, food modal, food search, star rating,
+ * Sage — front-end glue (auth tabs, food modal, food search, star rating,
  * theme toggle, mobile sidebar drawer).
  *
  * AI acknowledgment (COMP2850 amber-rated AI use):

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Good Food — Sign in</title>
+    <title>Sage — Sign in</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="auth-body">
@@ -11,8 +11,8 @@
     <div class="auth-card card">
         <button type="button" class="auth-theme-toggle js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <div class="auth-brand">
-            <span class="auth-logo" aria-hidden="true">🥗</span>
-            <h1 class="auth-title">Good Food</h1>
+            <span class="auth-logo" aria-hidden="true"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <h1 class="auth-title">Sage</h1>
             <p class="auth-sub">Healthy eating, tracked simply.</p>
         </div>
 

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title th:text="${client.fullName} + ' — Client'">Client — Good Food</title>
+    <title th:text="${client.fullName} + ' — Client'">Client — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">📋</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Professional dashboard — Good Food</title>
+    <title>Professional dashboard — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">📋</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Messages — Pro — Good Food</title>
+    <title>Messages — Pro — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">📋</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Dashboard — Good Food</title>
+    <title>Dashboard — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Food diary — Good Food</title>
+    <title>Food diary — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Nutrition goals — Good Food</title>
+    <title>Nutrition goals — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Messages — Good Food</title>
+    <title>Messages — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Profile — Good Food</title>
+    <title>Profile — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title th:text="${recipe.title} + ' — Good Food'">Recipe — Good Food</title>
+    <title th:text="${recipe.title} + ' — Sage'">Recipe — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <title>Recipes — Good Food</title>
+    <title>Recipes — Sage</title>
     <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
 </head>
 <body class="app-body">
@@ -13,8 +13,8 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo">🥗</span>
-            <span class="sidebar__title">Good Food</span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>
         <nav class="sidebar__nav" aria-label="Main">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Good Food & Healthy Eating
+# Sage — Healthy Eating
 
 COMP2850 Software Engineering — Group Project
 


### PR DESCRIPTION
Closes #83.

## Summary
- Product renamed **Good Food → Sage** across every user-facing string (11 page titles, 8 sidebar brand texts, the auth title).
- `🥗` salad emoji and `📋` pro-clipboard emoji both replaced with a single inline-SVG **sage-leaf mark** (`stroke="currentColor"` so it inherits the existing logo-disc foreground and flips in dark mode).
- `.auth-logo` CSS switched from text-centering to `inline-flex` so the SVG centers cleanly.
- File-header doc comments in `styles.css` / `app.js` / `UserService.kt` and the README + CHANGELOG title lines updated.
- **Not changed**: Kotlin package `com.goodfood.*` (internal architecture, not a brand surface).

## Why "Sage"

- The brand color already lives in the design system as `--color-sage-deep` / `--color-sage` / `--color-sage-bg`. Name + visual identity collapse into one cohesive thing.
- Sage is a culinary herb — food-coded, not the "FitFlow / NutriSmart" startup-slop pattern (taste-skill rule: "NO Startup Slop Names").
- "Sage" also means "wise" — fits a product whose job is helping users make smarter food choices.
- One syllable, real word, premium minimal feel.

## Test plan
- [ ] Visit every authenticated page (`/dashboard`, `/diary`, `/recipes`, `/recipe/:id`, `/goals`, `/messages`, `/profile`) — sidebar shows the leaf SVG + "Sage" title, browser tab shows "<Page> — Sage".
- [ ] Visit `/login` — auth card shows the leaf SVG + "Sage" wordmark + "Healthy eating, tracked simply." subtitle.
- [ ] Switch to dark mode — leaf strokes flip from cream to dark forest (matching `--color-primary-on`); logo disc stays sage.
- [ ] Visit a professional dashboard route — sidebar shows the same Sage leaf, but title still reads "Pro portal" so practitioners know which mode they're in.
- [ ] Verify no `🥗` or `📋` remains in any rendered page.