### PR TITLE
feat: refine Sage logo — solid asymmetric leaf with negative-space midrib (v0.6.19)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.19] - 2026-05-03 — Logo refinement: solid asymmetric leaf with negative-space midrib (closes #85)
+
+### Changed
+- Replaced the v0.6.18 hollow-outline + centered-midrib leaf (the LLM-default "minimal leaf" archetype, fragile at 18px) with a solid asymmetric silhouette + a negative-space cut for the midrib. Two-path SVG, single asset, used at all 12 logo placements (8 subscriber sidebars + 3 professional sidebars + 1 auth disc).
+- **Body** is filled with `currentColor` so it inherits the disc's foreground (cream in light, dark forest in dark) — substantial at 18px instead of wispy.
+- **Midrib** is a stroke painted with `var(--color-primary)` — i.e. the disc's own background color — so the cut visually punches through the leaf and reveals the disc behind. Same SVG, no extra assets, but a FedEx-arrow-tier negative-space wit moment.
+- The leaf silhouette is intentionally asymmetric: denser curvature on the bottom-left, sharper terminus on the upper-right. Reads as a sage leaf with organic visual weight rather than a generic teardrop.
+
+---
+
 ## [v0.6.18] - 2026-05-03 — Rebrand: Good Food → Sage, salad emoji → SVG sage-leaf mark (closes #83)
 
 ### Changed

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -11,7 +11,7 @@
     <div class="auth-card card">
         <button type="button" class="auth-theme-toggle js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <div class="auth-brand">
-            <span class="auth-logo" aria-hidden="true"><svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="auth-logo" aria-hidden="true"><svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <h1 class="auth-title">Sage</h1>
             <p class="auth-sub">Healthy eating, tracked simply.</p>
         </div>

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19 C 5 10, 11 4, 19 4 C 19 13, 13 19, 5 19 Z"/><path d="M5 19 L 19 4"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>


### PR DESCRIPTION
Closes #85.

## Summary
- Replaced the v0.6.18 hollow-outline + centered-midrib leaf (the LLM-default "minimal leaf" archetype, fragile at 18px) with a solid asymmetric silhouette + a negative-space cut for the midrib.
- **Body**: filled `currentColor` (cream in light, dark forest in dark) — substantial at small sizes.
- **Midrib**: stroked with `var(--color-primary)` — the disc's own background color — so the cut visually punches through the leaf and reveals the disc behind. Same SVG, no extra assets, but a FedEx-arrow-tier negative-space wit moment.
- Leaf silhouette is intentionally asymmetric (denser curvature on the bottom-left, sharper terminus on the upper-right) so it reads as a sage leaf with organic weight, not a generic teardrop.
- Single SVG, 12 placements (8 subscriber + 3 professional sidebars + 1 auth disc).

## Test plan
- [ ] Visit any subscriber page — sidebar disc shows a solid filled leaf with a sage-colored "vein" cutting diagonally through it.
- [ ] Visit `/login` — same mark at 26px in the 48px disc, the negative-space cut reads more clearly at the larger size.
- [ ] Toggle dark mode — leaf body flips from cream to dark forest, the midrib (`--color-primary`) flips from sage to lighter sage; the negative-space-cut effect persists in both modes.
- [ ] Inspect the SVG in DevTools — confirm the second path uses `stroke="var(--color-primary)"` and the parent disc's `background` resolves to the same color.
- [ ] Visit a professional dashboard — same mark, "Pro portal" subtitle still reads.