### PR TITLE
feat: public landing page at / with scroll-reveal animations (v0.6.20)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.20] - 2026-05-03 — Public landing page at / with scroll-reveal animations (closes #87)
+
+### Added
+- New `templates/landing.html` served at `/` for unauthenticated visitors. Authenticated users still go straight to their dashboard. Replaces the previous behavior of dumping new visitors on a bare login form.
+- **Asymmetric hero** (taste-skill rule: no centered hero when `DESIGN_VARIANCE > 4`): split-screen with `1.1fr 1fr` grid; left column carries the headline + sub + dual CTAs ("Start free" / "I have an account"); right column shows the brand disc with three floating metric chips (`1,842 kcal today` / `124 g protein` / `187 recipes saved`) — each chip drifts on a perpetual `hero-metric-float` keyframe with 6s alternating easing.
+- **Three zig-zag feature sections** (Track / Cook / Coach) — section 2 reverses via `.landing-section--reverse` so visuals alternate sides; type-driven CSS-only mocks instead of stock photography (a calorie ring with macro bars / a stacked recipe-card vignette / a mock chat thread with breathing typing-dots).
+- **Closing CTA band** in `--color-deep` (forest) with `Create your account` / `Sign in` buttons, then a minimal footer.
+- **IntersectionObserver scroll reveals**: every `[data-reveal]` element gets `opacity: 0; transform: translateY(28px)` until it crosses 15% of the viewport, then transitions in over 0.8s with `cubic-bezier(0.16, 1, 0.3, 1)` easing and an `--i`-driven 90ms stagger. Falls back to instant visibility when `prefers-reduced-motion: reduce` or `IntersectionObserver` is unsupported.
+
+### Changed
+- `Routing.kt`'s root `get("/")` now renders the landing template directly for unauthenticated users (instead of `respondRedirect("/login")`); authenticated branch unchanged.
+- `initCountUp()` in `app.js` now prefers a `data-count-up="..."` attribute value over text content, strips thousands-separator commas before parsing, and re-adds them via `toLocaleString("en-US")` if the source had them — backward compatible with the existing dashboard usage that sets the value via text content.
+- New `initScrollReveals()` function added to `app.js`'s init sequence.
+
+---
+
 ## [v0.6.19] - 2026-05-03 — Logo refinement: solid asymmetric leaf with negative-space midrib (closes #85)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/config/Routing.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Routing.kt
@@ -15,6 +15,7 @@ import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
+import io.ktor.server.thymeleaf.*
 
 fun Application.configureRouting() {
     install(StatusPages) {
@@ -35,13 +36,16 @@ fun Application.configureRouting() {
         profileRoutes()
         professionalRoutes()
 
+        // Authenticated users go straight to their dashboard. Unauthenticated visitors
+        // see the marketing landing page instead of being dumped on the bare login form
+        // — gives them a chance to understand what Sage is before signing up.
         get("/") {
             val session = call.sessions.get<UserSession>()
             if (session != null) {
                 if (session.role == "professional") call.respondRedirect("/pro/dashboard")
                 else call.respondRedirect("/dashboard")
             } else {
-                call.respondRedirect("/login")
+                call.respond(ThymeleafContent("landing", emptyMap()))
             }
         }
     }

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2430,6 +2430,510 @@ input::placeholder, textarea::placeholder {
 }
 
 /* ============================================================
+   Landing page — public marketing route at /
+   Built for unauthenticated visitors. Asymmetric hero, zig-zag
+   feature sections, type-driven (no stock photography), motion
+   gated behind prefers-reduced-motion: no-preference.
+   ============================================================ */
+.landing-body {
+    background: var(--color-bg);
+    color: var(--text);
+    overflow-x: hidden;
+}
+
+.landing-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    padding: 24px 40px;
+    max-width: 1320px;
+    margin: 0 auto;
+}
+.landing-nav__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    text-decoration: none;
+    color: var(--text-strong);
+}
+.landing-nav__mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-pill);
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+}
+.landing-nav__wordmark {
+    font-weight: 700;
+    font-size: var(--text-lg);
+    letter-spacing: var(--tracking-tight);
+}
+.landing-nav__links {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.landing-nav__theme {
+    background: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--text-soft);
+    padding: 7px 14px;
+    border-radius: var(--radius-pill);
+    font: inherit;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    cursor: pointer;
+}
+.landing-nav__theme:hover { background: var(--color-surface-warm); }
+
+/* ---- HERO ---- */
+.landing-hero {
+    position: relative;
+    min-height: calc(100dvh - 80px);
+    max-width: 1320px;
+    margin: 0 auto;
+    padding: 60px 40px 100px;
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    align-items: center;
+    gap: 80px;
+}
+.landing-hero__eyebrow {
+    margin: 0 0 32px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.32em;
+    color: var(--color-primary);
+    text-transform: uppercase;
+}
+.landing-hero__title {
+    margin: 0 0 28px;
+    font-size: clamp(56px, 9vw, 120px);
+    line-height: 0.92;
+    letter-spacing: -0.04em;
+    color: var(--text-strong);
+    font-weight: 700;
+}
+.landing-hero__title-accent {
+    color: var(--color-primary);
+    font-style: italic;
+    font-weight: 600;
+}
+.landing-hero__sub {
+    margin: 0 0 40px;
+    font-size: clamp(16px, 1.6vw, 19px);
+    line-height: 1.55;
+    color: var(--text-soft);
+    max-width: 520px;
+}
+.landing-hero__ctas {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+}
+.landing-hero__cta { padding: 14px 28px; font-size: var(--text-body); }
+.landing-hero__cta.btn--block { width: auto; }
+
+.landing-hero__visual {
+    position: relative;
+    aspect-ratio: 1;
+    max-height: 520px;
+    width: 100%;
+}
+.landing-hero__disc {
+    position: absolute;
+    inset: 12% 18% 12% 0;
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow-lg);
+}
+.landing-hero__leaf {
+    width: 52%;
+    height: 52%;
+}
+.landing-hero__metric {
+    position: absolute;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    padding: 14px 18px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 130px;
+}
+.landing-hero__metric-num {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    color: var(--text-strong);
+    letter-spacing: -0.02em;
+}
+.landing-hero__metric-label {
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--text-soft);
+    font-weight: 600;
+}
+.landing-hero__metric--cal  { top: 8%;  right: 0; }
+.landing-hero__metric--prot { bottom: 18%; right: 8%; }
+.landing-hero__metric--rec  { bottom: 4%; left: 6%; }
+
+/* ---- SECTIONS (zig-zag) ---- */
+.landing-section {
+    max-width: 1320px;
+    margin: 0 auto;
+    padding: 120px 40px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+    gap: 100px;
+}
+.landing-section--reverse .landing-section__visual { order: -1; }
+
+.landing-section__eyebrow {
+    margin: 0 0 24px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.32em;
+    color: var(--color-primary);
+    text-transform: uppercase;
+}
+.landing-section__title {
+    margin: 0 0 24px;
+    font-size: clamp(36px, 5.5vw, 72px);
+    line-height: 0.96;
+    letter-spacing: -0.03em;
+    color: var(--text-strong);
+    font-weight: 700;
+}
+.landing-section__sub {
+    margin: 0;
+    font-size: clamp(15px, 1.4vw, 18px);
+    line-height: 1.6;
+    color: var(--text-soft);
+    max-width: 460px;
+}
+
+/* ---- Section visuals (CSS-only mocks) ---- */
+.landing-mock {
+    position: relative;
+    aspect-ratio: 1;
+    max-height: 460px;
+    width: 100%;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    overflow: hidden;
+}
+
+/* ring + bars — TRACK section */
+.landing-mock--ring { gap: 28px; }
+.landing-mock__ring {
+    width: 180px;
+    height: 180px;
+    margin: 8px auto 0;
+    border-radius: 50%;
+    background: conic-gradient(var(--color-sage-deep) 0%, var(--color-sage) 73%, var(--color-progress-track) 73% 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+.landing-mock__ring::after {
+    content: "";
+    position: absolute;
+    inset: 14px;
+    background: var(--color-surface);
+    border-radius: 50%;
+}
+.landing-mock__ring-num {
+    position: relative;
+    z-index: 1;
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: 44px;
+    font-weight: 700;
+    color: var(--text-strong);
+    line-height: 1;
+}
+.landing-mock__ring-pct { font-size: 24px; color: var(--text-soft); margin-left: 2px; }
+.landing-mock__ring-label {
+    position: absolute;
+    bottom: 38px;
+    z-index: 1;
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--text-soft);
+    font-weight: 600;
+}
+.landing-mock__bars { display: flex; flex-direction: column; gap: 10px; }
+.landing-mock__bar {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 10px;
+    align-items: center;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+    font-weight: 600;
+}
+.landing-mock__bar em {
+    grid-column: 2;
+    font-style: normal;
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+}
+.landing-mock__bar > span {
+    grid-column: 1;
+    height: 8px;
+    background: var(--color-progress-track);
+    border-radius: var(--radius-pill);
+    position: relative;
+}
+.landing-mock__bar > span::after {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: var(--w);
+    background: linear-gradient(90deg, var(--color-sage-deep), var(--color-sage));
+    border-radius: inherit;
+}
+
+/* recipe-card stack — COOK section */
+.landing-mock--cards {
+    background: var(--color-surface-warm);
+    padding: 32px 28px;
+    gap: 0;
+}
+.landing-mock__card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    padding: 14px;
+    display: grid;
+    grid-template-columns: 64px 1fr auto;
+    align-items: center;
+    column-gap: 14px;
+    box-shadow: var(--shadow-sm);
+    position: relative;
+}
+.landing-mock__card strong {
+    grid-column: 2;
+    font-size: var(--text-sm);
+    color: var(--text-strong);
+    font-weight: 700;
+}
+.landing-mock__card span:not(.landing-mock__rating) {
+    grid-column: 2;
+    font-size: var(--text-xs);
+    color: var(--text-soft);
+}
+.landing-mock__rating {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    font-size: var(--text-sm);
+    color: var(--color-primary);
+    font-weight: 700;
+    align-self: center;
+}
+.landing-mock__card-cover {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    width: 64px;
+    height: 64px;
+    border-radius: var(--radius-sm);
+}
+.landing-mock__card-cover--sage  { background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft)); }
+.landing-mock__card-cover--clay  { background: linear-gradient(135deg, var(--color-clay-bg), var(--color-clay-soft)); }
+.landing-mock__card-cover--berry { background: linear-gradient(135deg, var(--color-berry-soft), var(--color-berry-tint)); }
+.landing-mock__card--a { transform: translateY(-12px); }
+.landing-mock__card--b { transform: translateY(0); margin: 12px 0; }
+.landing-mock__card--c { transform: translateY(12px); }
+
+/* chat — COACH section */
+.landing-mock--chat {
+    background: linear-gradient(180deg, var(--chat-bg-grad-from), var(--chat-bg-grad-to));
+    gap: 12px;
+    justify-content: flex-end;
+}
+.landing-mock__bubble {
+    max-width: 78%;
+    padding: 12px 16px;
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    line-height: 1.5;
+    color: var(--text-strong);
+    background: var(--bubble-them-bg);
+}
+.landing-mock__bubble strong {
+    display: block;
+    font-size: var(--text-xs);
+    color: var(--color-primary);
+    margin-bottom: 4px;
+    letter-spacing: var(--tracking-snug);
+}
+.landing-mock__bubble p { margin: 0; }
+.landing-mock__bubble time {
+    display: block;
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--text-soft);
+}
+.landing-mock__bubble--me {
+    margin-left: auto;
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+}
+.landing-mock__bubble--me time { color: var(--color-primary-on); opacity: 0.7; }
+.landing-mock__bubble--typing {
+    display: inline-flex;
+    gap: 4px;
+    padding: 14px 18px;
+    width: auto;
+    align-self: flex-start;
+}
+.landing-mock__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-soft);
+    opacity: 0.5;
+}
+
+/* ---- CLOSING CTA ---- */
+.landing-cta {
+    background: var(--color-deep);
+    color: var(--color-cream);
+    padding: 140px 40px;
+    text-align: center;
+}
+:root[data-theme="dark"] .landing-cta {
+    background: #0d1410;
+}
+.landing-cta__inner {
+    max-width: 800px;
+    margin: 0 auto;
+}
+.landing-cta__title {
+    margin: 0 0 16px;
+    font-size: clamp(44px, 7vw, 88px);
+    line-height: 0.96;
+    letter-spacing: -0.04em;
+    font-weight: 700;
+    color: var(--color-cream);
+}
+.landing-cta__sub {
+    margin: 0 0 40px;
+    font-size: clamp(15px, 1.5vw, 18px);
+    color: rgba(251, 248, 240, 0.72);
+}
+.landing-cta__buttons {
+    display: inline-flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+.landing-cta__btn { padding: 14px 28px; }
+.landing-cta .btn--ghost {
+    background: transparent;
+    color: var(--color-cream);
+    border-color: rgba(251, 248, 240, 0.3);
+}
+.landing-cta .btn--ghost:hover { background: rgba(251, 248, 240, 0.08); }
+
+.landing-footer {
+    padding: 32px 40px 48px;
+    text-align: center;
+    color: var(--text-soft);
+    font-size: var(--text-sm);
+    background: var(--color-deep);
+    color: rgba(251, 248, 240, 0.5);
+}
+:root[data-theme="dark"] .landing-footer { background: #0d1410; }
+
+/* ---- REVEAL ANIMATION ---- */
+[data-reveal] {
+    /* default state: hidden until JS adds .is-revealed */
+    opacity: 1;
+}
+@media (prefers-reduced-motion: no-preference) {
+    [data-reveal] {
+        opacity: 0;
+        transform: translateY(28px);
+        transition:
+            opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
+            transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+        transition-delay: calc(var(--i, 0) * 90ms);
+    }
+    [data-reveal].is-revealed {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    /* Hero metric chips: subtle perpetual float */
+    .landing-hero__metric {
+        animation: hero-metric-float 6s var(--ease) infinite alternate;
+    }
+    .landing-hero__metric--prot { animation-delay: -2s; }
+    .landing-hero__metric--rec  { animation-delay: -4s; }
+    /* Typing dots */
+    .landing-mock__dot { animation: typing-pulse 1.4s ease-in-out infinite; }
+    .landing-mock__dot:nth-child(2) { animation-delay: 0.2s; }
+    .landing-mock__dot:nth-child(3) { animation-delay: 0.4s; }
+}
+@keyframes hero-metric-float {
+    from { transform: translateY(0); }
+    to   { transform: translateY(-8px); }
+}
+@keyframes typing-pulse {
+    0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+    30%           { opacity: 1;   transform: translateY(-3px); }
+}
+
+/* ---- Landing responsive ---- */
+@media (max-width: 960px) {
+    .landing-hero {
+        grid-template-columns: 1fr;
+        gap: 40px;
+        padding-bottom: 80px;
+    }
+    .landing-hero__visual { max-height: 360px; }
+    .landing-section {
+        grid-template-columns: 1fr;
+        gap: 48px;
+        padding: 80px 32px;
+    }
+    .landing-section--reverse .landing-section__visual { order: 0; }
+    .landing-cta { padding: 100px 32px; }
+}
+@media (max-width: 560px) {
+    .landing-nav { padding: 20px 24px; }
+    .landing-nav__theme { display: none; }
+    .landing-hero { padding: 40px 24px 64px; }
+    .landing-section { padding: 64px 24px; }
+    .landing-mock { padding: 24px; max-height: 380px; }
+    .landing-hero__metric { padding: 10px 14px; min-width: 110px; }
+    .landing-hero__metric-num { font-size: var(--text-xl); }
+}
+
+/* ============================================================
    Responsive
    ============================================================ */
 @media (max-width: 1024px) {

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -245,12 +245,17 @@
         if (!nodes.length) return;
         var DURATION = 700;
         Array.prototype.forEach.call(nodes, function (el) {
-            var raw = (el.textContent || "").trim();
-            var target = parseFloat(raw);
-            if (isNaN(target)) return;
+            var attrVal = el.getAttribute("data-count-up");
+            var raw = (attrVal && attrVal.length ? attrVal : (el.textContent || "")).trim();
+            var hadComma = raw.indexOf(",") !== -1;
             var hasDecimal = raw.indexOf(".") !== -1;
+            var target = parseFloat(raw.replace(/,/g, ""));
+            if (isNaN(target)) return;
             var fmt = function (v) {
-                return hasDecimal ? v.toFixed(1) : Math.round(v).toString();
+                if (hasDecimal) return v.toFixed(1);
+                var n = Math.round(v);
+                // Re-comma 4-digit+ numbers if the source had thousands separators.
+                return hadComma ? n.toLocaleString("en-US") : n.toString();
             };
             el.textContent = fmt(0);
             var startedAt = performance.now();
@@ -264,6 +269,29 @@
             }
             requestAnimationFrame(frame);
         });
+    }
+
+    /* ---- Scroll reveals: landing-page IntersectionObserver. Adds .is-revealed
+           when an element with [data-reveal] crosses ~15% of the viewport. ---- */
+    function initScrollReveals() {
+        var nodes = document.querySelectorAll("[data-reveal]");
+        if (!nodes.length) return;
+        // No-IO fallback or reduced-motion: just reveal everything immediately —
+        // the CSS rule for [data-reveal] is no-op outside prefers-reduced-motion: no-preference.
+        if (!("IntersectionObserver" in window) ||
+            (window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches)) {
+            Array.prototype.forEach.call(nodes, function (el) { el.classList.add("is-revealed"); });
+            return;
+        }
+        var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add("is-revealed");
+                    io.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.15, rootMargin: "0px 0px -10% 0px" });
+        Array.prototype.forEach.call(nodes, function (el) { io.observe(el); });
     }
 
     /* Apply saved theme synchronously (before DOMContentLoaded) to avoid flash */
@@ -282,5 +310,6 @@
         initTheme();
         initSidebarDrawer();
         initCountUp();
+        initScrollReveals();
     });
 })();

--- a/2850final project/src/main/resources/templates/landing.html
+++ b/2850final project/src/main/resources/templates/landing.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Sage — Eat with intention</title>
+    <link rel="stylesheet" th:href="'/static/css/styles.css'" href="/static/css/styles.css"/>
+</head>
+<body class="landing-body">
+<a href="#main" class="skip-link">Skip to main content</a>
+
+<header class="landing-nav">
+    <a href="/" class="landing-nav__brand" aria-label="Sage home">
+        <span class="landing-nav__mark" aria-hidden="true">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/>
+                <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+            </svg>
+        </span>
+        <span class="landing-nav__wordmark">Sage</span>
+    </a>
+    <div class="landing-nav__links">
+        <button type="button" class="landing-nav__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
+        <a href="/login" class="btn btn--ghost btn--small">Sign in</a>
+        <a href="/login?tab=register" class="btn btn--primary btn--small">Start free</a>
+    </div>
+</header>
+
+<main id="main" class="landing-main">
+
+    <!-- ========== HERO ========== -->
+    <section class="landing-hero">
+        <div class="landing-hero__copy">
+            <p class="landing-hero__eyebrow" data-reveal style="--i:0">SAGE — HEALTHY EATING, TRACKED SIMPLY</p>
+            <h1 class="landing-hero__title" data-reveal style="--i:1">
+                Eat with<br/>
+                <span class="landing-hero__title-accent">intention.</span>
+            </h1>
+            <p class="landing-hero__sub" data-reveal style="--i:2">
+                Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one. Built for people who'd rather know than guess.
+            </p>
+            <div class="landing-hero__ctas" data-reveal style="--i:3">
+                <a href="/login?tab=register" class="btn btn--primary btn--block landing-hero__cta">Start free</a>
+                <a href="/login" class="btn btn--ghost landing-hero__cta">I have an account</a>
+            </div>
+        </div>
+        <div class="landing-hero__visual" aria-hidden="true">
+            <div class="landing-hero__disc">
+                <svg viewBox="0 0 24 24" fill="currentColor" class="landing-hero__leaf">
+                    <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/>
+                    <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+                </svg>
+            </div>
+            <div class="landing-hero__metric landing-hero__metric--cal">
+                <span class="landing-hero__metric-num" data-count-up="1842">1,842</span>
+                <span class="landing-hero__metric-label">kcal today</span>
+            </div>
+            <div class="landing-hero__metric landing-hero__metric--prot">
+                <span class="landing-hero__metric-num" data-count-up="124">124</span>
+                <span class="landing-hero__metric-label">g protein</span>
+            </div>
+            <div class="landing-hero__metric landing-hero__metric--rec">
+                <span class="landing-hero__metric-num" data-count-up="187">187</span>
+                <span class="landing-hero__metric-label">recipes saved</span>
+            </div>
+        </div>
+    </section>
+
+    <!-- ========== SECTION 1: TRACK ========== -->
+    <section class="landing-section" data-reveal>
+        <div class="landing-section__copy">
+            <p class="landing-section__eyebrow">Track</p>
+            <h2 class="landing-section__title">Every bite,<br/>in 6 seconds.</h2>
+            <p class="landing-section__sub">
+                Search 200+ verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring. No streaks, no shaming — just the number, when you want it.
+            </p>
+        </div>
+        <div class="landing-section__visual" aria-hidden="true">
+            <div class="landing-mock landing-mock--ring">
+                <div class="landing-mock__ring">
+                    <span class="landing-mock__ring-num">73<span class="landing-mock__ring-pct">%</span></span>
+                    <span class="landing-mock__ring-label">of goal</span>
+                </div>
+                <div class="landing-mock__bars">
+                    <div class="landing-mock__bar"><span style="--w:62%"></span><em>Protein</em></div>
+                    <div class="landing-mock__bar"><span style="--w:48%"></span><em>Carbs</em></div>
+                    <div class="landing-mock__bar"><span style="--w:81%"></span><em>Fat</em></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ========== SECTION 2: COOK (zig-zag, visual on left) ========== -->
+    <section class="landing-section landing-section--reverse" data-reveal>
+        <div class="landing-section__copy">
+            <p class="landing-section__eyebrow">Cook</p>
+            <h2 class="landing-section__title">Recipes that travel<br/>with you.</h2>
+            <p class="landing-section__sub">
+                180+ home-cooking recipes with macros pre-calculated. Save the ones that fit your week. Rate them after dinner — the ones you keep cooking float to the top.
+            </p>
+        </div>
+        <div class="landing-section__visual" aria-hidden="true">
+            <div class="landing-mock landing-mock--cards">
+                <article class="landing-mock__card landing-mock__card--a">
+                    <div class="landing-mock__card-cover landing-mock__card-cover--sage"></div>
+                    <strong>Sesame soba bowl</strong>
+                    <span>520 kcal · 22g protein</span>
+                    <span class="landing-mock__rating">★ 4.6</span>
+                </article>
+                <article class="landing-mock__card landing-mock__card--b">
+                    <div class="landing-mock__card-cover landing-mock__card-cover--clay"></div>
+                    <strong>Harissa salmon traybake</strong>
+                    <span>610 kcal · 41g protein</span>
+                    <span class="landing-mock__rating">★ 4.8</span>
+                </article>
+                <article class="landing-mock__card landing-mock__card--c">
+                    <div class="landing-mock__card-cover landing-mock__card-cover--berry"></div>
+                    <strong>Yogurt &amp; stone-fruit bowl</strong>
+                    <span>320 kcal · 18g protein</span>
+                    <span class="landing-mock__rating">★ 4.4</span>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <!-- ========== SECTION 3: COACH ========== -->
+    <section class="landing-section" data-reveal>
+        <div class="landing-section__copy">
+            <p class="landing-section__eyebrow">Coach</p>
+            <h2 class="landing-section__title">A nutritionist<br/>on call.</h2>
+            <p class="landing-section__sub">
+                Direct-message a registered practitioner about a goal, a binge, or a Friday night. They reply in their actual voice — not a chatbot, not a canned reply, not a 24-hour wait.
+            </p>
+        </div>
+        <div class="landing-section__visual" aria-hidden="true">
+            <div class="landing-mock landing-mock--chat">
+                <div class="landing-mock__bubble landing-mock__bubble--them">
+                    <strong>Dr. Sarah Williams</strong>
+                    <p>Hey — saw your week. Friday's protein is light, want me to send 3 quick fixes you can grab from Tesco on the way home?</p>
+                    <time>Today · 16:42</time>
+                </div>
+                <div class="landing-mock__bubble landing-mock__bubble--me">
+                    <p>Yes please, and skip anything with feta this time</p>
+                    <time>Today · 16:43</time>
+                </div>
+                <div class="landing-mock__bubble landing-mock__bubble--them landing-mock__bubble--typing">
+                    <span class="landing-mock__dot"></span>
+                    <span class="landing-mock__dot"></span>
+                    <span class="landing-mock__dot"></span>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- ========== CLOSING CTA ========== -->
+    <section class="landing-cta" data-reveal>
+        <div class="landing-cta__inner">
+            <h2 class="landing-cta__title">Start cooking<br/>with intention.</h2>
+            <p class="landing-cta__sub">Free to start. No credit card. Bring your appetite.</p>
+            <div class="landing-cta__buttons">
+                <a href="/login?tab=register" class="btn btn--primary landing-cta__btn">Create your account</a>
+                <a href="/login" class="btn btn--ghost landing-cta__btn">Sign in</a>
+            </div>
+        </div>
+    </section>
+
+    <footer class="landing-footer">
+        <p>Sage · COMP2850 group project · 2026</p>
+    </footer>
+
+</main>
+
+<script th:src="'/static/js/app.js'" src="/static/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #87. Inspired by whoop.com — fluid scroll reveals, asymmetric hero, type-driven (no stock photography).

## Summary
- New `templates/landing.html` served at `/` for unauthenticated visitors. Authenticated users still go straight to their dashboard.
- **Asymmetric hero** (`1.1fr / 1fr`): staggered reveal-on-load headline + sub + dual CTAs (Start free / Sign in) on the left; brand disc with three perpetually drifting metric chips on the right.
- **Three zig-zag feature sections** (Track / Cook / Coach) — section 2 reverses via `.landing-section--reverse` so visuals alternate sides. Type-driven CSS-only mocks: calorie ring with macro bars, stacked recipe-card vignette, mock chat with breathing typing-dots. No imagery dependencies.
- **Closing CTA band** on `--color-deep` (forest) with sign-up / sign-in.
- **IntersectionObserver scroll reveals**: every `[data-reveal]` element fades in + slides up when it crosses 15% of the viewport, staggered by `--i`, eased with `cubic-bezier(0.16, 1, 0.3, 1)`. Falls back to instant visibility under `prefers-reduced-motion: reduce` or no-IO browsers.

## Why type-driven, not stock photography
- taste-skill banned generic Unsplash placeholders — they make a project feel like a template, and they break offline / on slow connections.
- The CSS-only mocks reuse brand tokens (`--color-sage-bg/soft`, `--color-clay-bg/soft`, `--color-berry-soft/tint`) so dark mode flips them automatically — no separate dark assets to maintain.
- A landing made of typography + color blocks reads as a Linear / Stripe / Anthropic-tier site, not a school stock-photo template.

## What I changed in shared code (and why it's safe)
- `Routing.kt`: only the root route changes. Logged-in flow is byte-identical.
- `initCountUp()` in `app.js`: now prefers `data-count-up="N"` attribute over text content, strips commas, and re-adds them via `toLocaleString` if the source had them. Existing dashboard usage (`<strong th:text="${totalProtein}" data-count-up>0</strong>`) has no attribute value so it falls through to the textContent path — behavior unchanged.

## Test plan
- [ ] Visit `/` while signed out — landing renders; scroll down to see Track / Cook / Coach reveal as they enter the viewport.
- [ ] Click `Start free` → goes to `/login?tab=register`. Click `Sign in` → goes to `/login`.
- [ ] Sign in, then visit `/` — redirects to `/dashboard` (or `/pro/dashboard` for professionals). Logged-in flow is unchanged.
- [ ] Toggle the theme button in the top-right nav — landing flips to dark mode; the recipe-card mock covers, chat gradient, ring conic, and CTA band all swap correctly.
- [ ] DevTools → Rendering → `prefers-reduced-motion: reduce` — reveals fire immediately, hero metric chips stop floating, typing dots stop pulsing.
- [ ] Resize to ~900px — hero collapses to single column, zig-zag sections collapse to single column with visuals coming after copy in source order.
- [ ] Resize to ~500px — nav theme toggle hides; hero metric chips shrink. No horizontal scroll.