### PR TITLE
feat: landing at / for ALL users with session-aware CTAs (v0.6.21)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.21] - 2026-05-03 — Landing at / for ALL users with session-aware CTAs (closes #89)
+
+### Changed
+- `Routing.kt`: `get("/")` no longer redirects authenticated users to their dashboard — the landing page is now the entry point for everyone. The session is passed through to the template so CTAs adapt.
+- `landing.html`: every CTA cluster (top nav, hero, closing CTA band) splits into a `${session == null}` branch and a `${session != null}` branch via `<th:block>`.
+  - Signed-out: `Sign in` / `Start free`, `Start free` / `I have an account`, `Create your account` / `Sign in` (unchanged copy).
+  - Signed-in: `Go to dashboard` / `Sign out` everywhere; the closing band's headline becomes `Welcome back, <fullName>.` with a `Pick up where you left off.` subtitle pointing into the app.
+- The pro/subscriber dashboard distinction is preserved — every "Go to dashboard" link uses `${session.role == 'professional'} ? '/pro/dashboard' : '/dashboard'` so practitioners still land in their portal.
+
+---
+
 ## [v0.6.20] - 2026-05-03 — Public landing page at / with scroll-reveal animations (closes #87)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/config/Routing.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Routing.kt
@@ -36,17 +36,12 @@ fun Application.configureRouting() {
         profileRoutes()
         professionalRoutes()
 
-        // Authenticated users go straight to their dashboard. Unauthenticated visitors
-        // see the marketing landing page instead of being dumped on the bare login form
-        // — gives them a chance to understand what Sage is before signing up.
+        // The landing page is the entry point for everyone — signed-out and signed-in
+        // alike. The template adapts its CTAs based on whether `session` is present
+        // (Sign in / Start free vs Go to dashboard / Sign out).
         get("/") {
             val session = call.sessions.get<UserSession>()
-            if (session != null) {
-                if (session.role == "professional") call.respondRedirect("/pro/dashboard")
-                else call.respondRedirect("/dashboard")
-            } else {
-                call.respond(ThymeleafContent("landing", emptyMap()))
-            }
+            call.respond(ThymeleafContent("landing", model("session" to session)))
         }
     }
 }

--- a/2850final project/src/main/resources/templates/landing.html
+++ b/2850final project/src/main/resources/templates/landing.html
@@ -21,8 +21,15 @@
     </a>
     <div class="landing-nav__links">
         <button type="button" class="landing-nav__theme js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
-        <a href="/login" class="btn btn--ghost btn--small">Sign in</a>
-        <a href="/login?tab=register" class="btn btn--primary btn--small">Start free</a>
+        <th:block th:if="${session == null}">
+            <a href="/login" class="btn btn--ghost btn--small">Sign in</a>
+            <a href="/login?tab=register" class="btn btn--primary btn--small">Start free</a>
+        </th:block>
+        <th:block th:if="${session != null}">
+            <a th:href="${session.role == 'professional'} ? '/pro/dashboard' : '/dashboard'"
+               class="btn btn--primary btn--small">Go to dashboard</a>
+            <a href="/logout" class="btn btn--ghost btn--small">Sign out</a>
+        </th:block>
     </div>
 </header>
 
@@ -40,8 +47,15 @@
                 Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one. Built for people who'd rather know than guess.
             </p>
             <div class="landing-hero__ctas" data-reveal style="--i:3">
-                <a href="/login?tab=register" class="btn btn--primary btn--block landing-hero__cta">Start free</a>
-                <a href="/login" class="btn btn--ghost landing-hero__cta">I have an account</a>
+                <th:block th:if="${session == null}">
+                    <a href="/login?tab=register" class="btn btn--primary btn--block landing-hero__cta">Start free</a>
+                    <a href="/login" class="btn btn--ghost landing-hero__cta">I have an account</a>
+                </th:block>
+                <th:block th:if="${session != null}">
+                    <a th:href="${session.role == 'professional'} ? '/pro/dashboard' : '/dashboard'"
+                       class="btn btn--primary btn--block landing-hero__cta">Go to dashboard</a>
+                    <a href="/logout" class="btn btn--ghost landing-hero__cta">Sign out</a>
+                </th:block>
             </div>
         </div>
         <div class="landing-hero__visual" aria-hidden="true">
@@ -154,12 +168,21 @@
 
     <!-- ========== CLOSING CTA ========== -->
     <section class="landing-cta" data-reveal>
-        <div class="landing-cta__inner">
+        <div class="landing-cta__inner" th:if="${session == null}">
             <h2 class="landing-cta__title">Start cooking<br/>with intention.</h2>
             <p class="landing-cta__sub">Free to start. No credit card. Bring your appetite.</p>
             <div class="landing-cta__buttons">
                 <a href="/login?tab=register" class="btn btn--primary landing-cta__btn">Create your account</a>
                 <a href="/login" class="btn btn--ghost landing-cta__btn">Sign in</a>
+            </div>
+        </div>
+        <div class="landing-cta__inner" th:if="${session != null}">
+            <h2 class="landing-cta__title">Welcome back,<br/><span th:text="${session.fullName}">friend</span>.</h2>
+            <p class="landing-cta__sub">Pick up where you left off.</p>
+            <div class="landing-cta__buttons">
+                <a th:href="${session.role == 'professional'} ? '/pro/dashboard' : '/dashboard'"
+                   class="btn btn--primary landing-cta__btn">Go to dashboard</a>
+                <a href="/logout" class="btn btn--ghost landing-cta__btn">Sign out</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Closes #89.

## Summary
- `/` no longer redirects signed-in users to their dashboard. The landing page is now the entry point for **everyone**.
- Every CTA cluster on `landing.html` (top nav, hero, closing band) splits into `${session == null}` / `${session != null}` branches:
  - **Signed-out**: copy unchanged — `Sign in` / `Start free`, `Start free` / `I have an account`, `Create your account` / `Sign in`.
  - **Signed-in**: `Go to dashboard` / `Sign out` everywhere; the closing band greets the user by name (`Welcome back, <fullName>.` with a `Pick up where you left off.` subtitle).
- Pro/subscriber distinction is preserved — every "Go to dashboard" link routes via `${session.role == 'professional'} ? '/pro/dashboard' : '/dashboard'`.

## Test plan
- [ ] Visit `/` while signed out — landing renders with the original `Sign in` / `Start free` CTAs.
- [ ] Sign in as a subscriber, visit `/` — landing still renders, top-nav and hero now show `Go to dashboard` / `Sign out`, closing band reads `Welcome back, <Your Name>.`.
- [ ] Click `Go to dashboard` from any of the three placements → arrives on `/dashboard`.
- [ ] Sign in as a professional, visit `/` — same flow but `Go to dashboard` routes to `/pro/dashboard`.
- [ ] Click `Sign out` → `/logout` clears session and redirects to `/login`.
- [ ] Direct navigation to `/dashboard` while signed in still works (this PR only changes `/`).