### PR TITLE
feat: oil-paint logo + Cormorant Garamond wordmark (v0.6.22)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.22] - 2026-05-03 — Logo oil-paint texture; "Sage" wordmark in Cormorant Garamond italic (closes #91)
+
+### Changed
+- **Logo painterly pass.** All 13 logo instances now wrap their leaf paths in a `<filter>` chain — `feTurbulence` (fractal noise, `baseFrequency: 0.85`, 2 octaves, `seed: 5`) feeding `feDisplacementMap` (`scale: 0.7`) — so path edges read as brush-flicked rather than CAD-clean. The leaf body fill switches from flat `currentColor` to a 3-stop `linearGradient` (`stop-opacity: 0.92 / 1 / 0.82`) so the pigment looks layered. The `var(--color-primary)` negative-space midrib survives the texture pass — brand wit intact.
+- The landing hero leaf gets its own `id="paintLg"` / `id="gradLg"` defs (slightly tighter `baseFrequency: 1.1`, `numOctaves: 3`, smaller `scale: 0.5`) because at large display sizes the same noise-frequency would over-distort. No ID collision with the smaller nav SVG above it.
+- **Wordmark typography flip.** Added Cormorant Garamond (Google Fonts) — a Garamond-tradition revival with the British book-typography lineage (Caslon → Baskerville → Penguin Classics → Vogue / Tatler mastheads). New `--font-display` token applied to:
+  - `.sidebar__title` — `italic 600` at 22px in every sidebar
+  - `.auth-title` — `italic 600` at 44px on the login disc
+  - `.landing-nav__wordmark` — `italic 600` at 26px in the top nav
+  - `.landing-hero__title-accent` — the "intention." accent word in the hero headline (the rest of "Eat with" stays in Plus Jakarta Sans), creating the classic British-editorial sans-with-one-italic-serif-word treatment
+- Body and dashboard typography unchanged — Plus Jakarta Sans still drives all UI text. Serif is brand-only, per taste-skill's "NEVER serif on dashboards" rule (which targets body/UI text, not wordmarks).
+
+---
+
 ## [v0.6.21] - 2026-05-03 — Landing at / for ALL users with session-aware CTAs (closes #89)
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600;1,700&display=swap");
 
 /* ============================================================
    Sage — warm wellness redesign (v0.6.0)
@@ -193,6 +193,7 @@
     /* type */
     --font-sans: "Plus Jakarta Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --font-display: "Cormorant Garamond", "Georgia", "Times New Roman", ui-serif, serif;
     --font: var(--font-sans);
 
     --text-xs:    12px;
@@ -560,13 +561,16 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     box-shadow: var(--shadow-sm);
 }
 
+/* Brand wordmark — Cormorant Garamond italic for that British editorial feel
+   (Vogue / Tatler / Penguin Classics lineage). Body type stays sans. */
 .auth-title {
     margin: 0;
-    font-family: var(--font);
-    font-size: var(--text-3xl);
-    font-weight: 700;
+    font-family: var(--font-display);
+    font-size: 44px;
+    font-weight: 600;
+    font-style: italic;
     line-height: var(--leading-tight);
-    letter-spacing: var(--tracking-tight);
+    letter-spacing: -0.01em;
     color: var(--text-strong);
 }
 
@@ -673,9 +677,12 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 }
 
 .sidebar__title {
-    font-weight: 700;
-    font-size: var(--text-base);
-    letter-spacing: var(--tracking-snug);
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 600;
+    font-size: 22px;
+    line-height: 1;
+    letter-spacing: 0;
 }
 
 .sidebar__user {
@@ -2468,9 +2475,12 @@ input::placeholder, textarea::placeholder {
     color: var(--color-primary-on);
 }
 .landing-nav__wordmark {
-    font-weight: 700;
-    font-size: var(--text-lg);
-    letter-spacing: var(--tracking-tight);
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 600;
+    font-size: 26px;
+    line-height: 1;
+    letter-spacing: 0;
 }
 .landing-nav__links {
     display: flex;
@@ -2519,9 +2529,14 @@ input::placeholder, textarea::placeholder {
     font-weight: 700;
 }
 .landing-hero__title-accent {
+    font-family: var(--font-display);
     color: var(--color-primary);
     font-style: italic;
     font-weight: 600;
+    /* serif italic optically reads larger than the surrounding sans, so
+       trim the size a touch to keep the line balanced */
+    font-size: 0.92em;
+    letter-spacing: -0.02em;
 }
 .landing-hero__sub {
     margin: 0 0 40px;

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -11,7 +11,7 @@
     <div class="auth-card card">
         <button type="button" class="auth-theme-toggle js-theme-toggle" aria-label="Toggle theme">Toggle theme</button>
         <div class="auth-brand">
-            <span class="auth-logo" aria-hidden="true"><svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="auth-logo" aria-hidden="true"><svg width="26" height="26" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <h1 class="auth-title">Sage</h1>
             <p class="auth-sub">Healthy eating, tracked simply.</p>
         </div>

--- a/2850final project/src/main/resources/templates/landing.html
+++ b/2850final project/src/main/resources/templates/landing.html
@@ -12,9 +12,22 @@
 <header class="landing-nav">
     <a href="/" class="landing-nav__brand" aria-label="Sage home">
         <span class="landing-nav__mark" aria-hidden="true">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/>
-                <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+            <svg width="22" height="22" viewBox="0 0 24 24">
+                <defs>
+                    <filter id="paint" x="-10%" y="-10%" width="120%" height="120%">
+                        <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/>
+                        <feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/>
+                    </filter>
+                    <linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%">
+                        <stop offset="0%"   stop-color="currentColor" stop-opacity="0.92"/>
+                        <stop offset="55%"  stop-color="currentColor" stop-opacity="1"/>
+                        <stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/>
+                    </linearGradient>
+                </defs>
+                <g filter="url(#paint)">
+                    <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/>
+                    <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+                </g>
             </svg>
         </span>
         <span class="landing-nav__wordmark">Sage</span>
@@ -60,9 +73,22 @@
         </div>
         <div class="landing-hero__visual" aria-hidden="true">
             <div class="landing-hero__disc">
-                <svg viewBox="0 0 24 24" fill="currentColor" class="landing-hero__leaf">
-                    <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/>
-                    <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+                <svg viewBox="0 0 24 24" class="landing-hero__leaf">
+                    <defs>
+                        <filter id="paintLg" x="-10%" y="-10%" width="120%" height="120%">
+                            <feTurbulence type="fractalNoise" baseFrequency="1.1" numOctaves="3" seed="7" result="n"/>
+                            <feDisplacementMap in="SourceGraphic" in2="n" scale="0.5"/>
+                        </filter>
+                        <linearGradient id="gradLg" x1="20%" y1="20%" x2="80%" y2="80%">
+                            <stop offset="0%"   stop-color="currentColor" stop-opacity="0.92"/>
+                            <stop offset="55%"  stop-color="currentColor" stop-opacity="1"/>
+                            <stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/>
+                        </linearGradient>
+                    </defs>
+                    <g filter="url(#paintLg)">
+                        <path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#gradLg)"/>
+                        <path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/>
+                    </g>
                 </svg>
             </div>
             <div class="landing-hero__metric landing-hero__metric--cal">

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar sidebar--pro">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Pro portal</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">Pro</p>

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/goals.html
+++ b/2850final project/src/main/resources/templates/subscriber/goals.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/profile.html
+++ b/2850final project/src/main/resources/templates/subscriber/profile.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipe-detail.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -13,7 +13,7 @@
 <div class="app-layout">
     <aside class="sidebar">
         <div class="sidebar__brand">
-            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></svg></span>
+            <span class="sidebar__logo" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 24 24"><defs><filter id="paint" x="-10%" y="-10%" width="120%" height="120%"><feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" seed="5" result="n"/><feDisplacementMap in="SourceGraphic" in2="n" scale="0.7"/></filter><linearGradient id="grad" x1="20%" y1="20%" x2="80%" y2="80%"><stop offset="0%" stop-color="currentColor" stop-opacity="0.92"/><stop offset="55%" stop-color="currentColor" stop-opacity="1"/><stop offset="100%" stop-color="currentColor" stop-opacity="0.82"/></linearGradient></defs><g filter="url(#paint)"><path d="M20 4 C 13 3, 4 9, 4 16 C 4 20, 7 20, 11 19 C 19 17, 21 11, 20 4 Z" fill="url(#grad)"/><path d="M8 16 C 11 12, 15 8, 18 5" fill="none" stroke="var(--color-primary)" stroke-width="2.2" stroke-linecap="round"/></g></svg></span>
             <span class="sidebar__title">Sage</span>
         </div>
         <p class="sidebar__user" th:if="${session}" th:text="${session.fullName}">User</p>


### PR DESCRIPTION
Closes #91.

## Summary
- **Logo painterly pass.** All 13 logo instances now wrap their paths in an SVG `<filter>` chain — `feTurbulence` (fractal noise) → `feDisplacementMap` — so edges read as brush-flicked rather than CAD-clean. Body fill switches from flat `currentColor` to a 3-stop linear gradient (`stop-opacity 0.92 / 1 / 0.82`) so the pigment looks layered. The `var(--color-primary)` negative-space midrib still cuts through to the disc behind, so the brand wit survives the texture pass.
- Landing hero leaf has its own `id="paintLg"` / `id="gradLg"` defs (tighter `baseFrequency: 1.1`, smaller `scale: 0.5`) so the texture stays controlled at display size and there's no ID collision with the smaller nav SVG on the same page.
- **"Sage" wordmark in Cormorant Garamond.** Added Cormorant Garamond to the Google Fonts import — Garamond-revival typeface, the British book-typography lineage (Caslon → Baskerville → Penguin Classics → Vogue / Tatler mastheads). New `--font-display` token applied at four brand surfaces:
  - `.sidebar__title` — italic 600 / 22px in every sidebar
  - `.auth-title` — italic 600 / 44px on the login disc
  - `.landing-nav__wordmark` — italic 600 / 26px in the top nav
  - `.landing-hero__title-accent` — the "intention." accent word in the hero headline; the rest of "Eat with" stays in Plus Jakarta Sans, giving the classic British-editorial sans-display-with-one-italic-serif-word treatment.
- **Body / dashboard text unchanged.** Plus Jakarta Sans still drives all UI text. Serif is brand-only — taste-skill's "NEVER serif on dashboards" rule targets body/UI text, not wordmarks.

## Test plan
- [ ] Visit `/` (signed out) — top nav shows the leaf with brushy edge irregularities and the *Sage* wordmark in italic Cormorant.
- [ ] Hero headline reads "Eat with *intention.*" — "intention." in italic Cormorant primary-color.
- [ ] Visit `/login` — disc shows a 26px brushy leaf, "*Sage*" headline below it in 44px italic Cormorant.
- [ ] Sign in, visit any subscriber page — sidebar shows brushy 18px leaf and "*Sage*" wordmark next to it in italic Cormorant.
- [ ] Toggle dark mode — leaf gradient flips with `currentColor`, the texture filter still applies, the negative-space midrib still reveals the disc color through the cut.
- [ ] Verify the landing hero leaf doesn't look over-distorted at its much larger size — that's why it has its own filter with tuned params.