### PR TITLE
fix: drop AI-template eyebrow caps, italic Cormorant editorial (v0.6.23)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.23] - 2026-05-03 — Eyebrows: drop tracked-caps AI pattern, italic Cormorant editorial (closes #93)
+
+### Changed
+- `.landing-hero__eyebrow` and `.landing-section__eyebrow` no longer use the `text-transform: uppercase; letter-spacing: 0.32em; font-size: 12px` recipe — that all-caps + wide-tracking + brief-tagline-in-eyebrow pattern is the Lovable / Bolt / v0.dev default and reads as AI-template at a glance.
+- Both classes now use `var(--font-display)` (Cormorant Garamond) at `italic 500`, natural case, no extra letter-spacing, larger size (`clamp(17px, 1.5vw, 20px)` hero / `clamp(16px, 1.4vw, 19px)` section) — serifs need the size and don't survive tracked-out caps. Reads as British-editorial subhead instead of marketing eyebrow.
+- Hero eyebrow copy: `SAGE — HEALTHY EATING, TRACKED SIMPLY` → `Healthy eating, tracked simply.` Drops the redundant brand prefix (the wordmark is right there in the nav above).
+- Section eyebrows: `Track` / `Cook` / `Coach` → `Track.` / `Cook.` / `Coach.` Period gives single-word eyebrows editorial weight.
+
+### Not changed
+- No new font added. Cormorant Garamond is already imported (v0.6.22).
+- All other typography (UI body, dashboard, mono numbers, sidebar wordmark) untouched.
+
+---
+
 ## [v0.6.22] - 2026-05-03 — Logo oil-paint texture; "Sage" wordmark in Cormorant Garamond italic (closes #91)
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2512,13 +2512,18 @@ input::placeholder, textarea::placeholder {
     align-items: center;
     gap: 80px;
 }
+/* Eyebrow — italic Cormorant editorial line. Replaces the all-caps + wide
+   letter-spacing pattern that reads as AI-template default. Natural case,
+   no tracking, slightly bigger because serifs need it. */
 .landing-hero__eyebrow {
-    margin: 0 0 32px;
-    font-size: var(--text-xs);
-    font-weight: 600;
-    letter-spacing: 0.32em;
+    margin: 0 0 28px;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 500;
+    font-size: clamp(17px, 1.5vw, 20px);
+    letter-spacing: 0;
     color: var(--color-primary);
-    text-transform: uppercase;
+    text-transform: none;
 }
 .landing-hero__title {
     margin: 0 0 28px;
@@ -2618,12 +2623,14 @@ input::placeholder, textarea::placeholder {
 .landing-section--reverse .landing-section__visual { order: -1; }
 
 .landing-section__eyebrow {
-    margin: 0 0 24px;
-    font-size: var(--text-xs);
-    font-weight: 600;
-    letter-spacing: 0.32em;
+    margin: 0 0 20px;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 500;
+    font-size: clamp(16px, 1.4vw, 19px);
+    letter-spacing: 0;
     color: var(--color-primary);
-    text-transform: uppercase;
+    text-transform: none;
 }
 .landing-section__title {
     margin: 0 0 24px;

--- a/2850final project/src/main/resources/templates/landing.html
+++ b/2850final project/src/main/resources/templates/landing.html
@@ -51,7 +51,7 @@
     <!-- ========== HERO ========== -->
     <section class="landing-hero">
         <div class="landing-hero__copy">
-            <p class="landing-hero__eyebrow" data-reveal style="--i:0">SAGE — HEALTHY EATING, TRACKED SIMPLY</p>
+            <p class="landing-hero__eyebrow" data-reveal style="--i:0">Healthy eating, tracked simply.</p>
             <h1 class="landing-hero__title" data-reveal style="--i:1">
                 Eat with<br/>
                 <span class="landing-hero__title-accent">intention.</span>
@@ -109,7 +109,7 @@
     <!-- ========== SECTION 1: TRACK ========== -->
     <section class="landing-section" data-reveal>
         <div class="landing-section__copy">
-            <p class="landing-section__eyebrow">Track</p>
+            <p class="landing-section__eyebrow">Track.</p>
             <h2 class="landing-section__title">Every bite,<br/>in 6 seconds.</h2>
             <p class="landing-section__sub">
                 Search 200+ verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring. No streaks, no shaming — just the number, when you want it.
@@ -133,7 +133,7 @@
     <!-- ========== SECTION 2: COOK (zig-zag, visual on left) ========== -->
     <section class="landing-section landing-section--reverse" data-reveal>
         <div class="landing-section__copy">
-            <p class="landing-section__eyebrow">Cook</p>
+            <p class="landing-section__eyebrow">Cook.</p>
             <h2 class="landing-section__title">Recipes that travel<br/>with you.</h2>
             <p class="landing-section__sub">
                 180+ home-cooking recipes with macros pre-calculated. Save the ones that fit your week. Rate them after dinner — the ones you keep cooking float to the top.
@@ -166,7 +166,7 @@
     <!-- ========== SECTION 3: COACH ========== -->
     <section class="landing-section" data-reveal>
         <div class="landing-section__copy">
-            <p class="landing-section__eyebrow">Coach</p>
+            <p class="landing-section__eyebrow">Coach.</p>
             <h2 class="landing-section__title">A nutritionist<br/>on call.</h2>
             <p class="landing-section__sub">
                 Direct-message a registered practitioner about a goal, a binge, or a Friday night. They reply in their actual voice — not a chatbot, not a canned reply, not a 24-hour wait.


### PR DESCRIPTION
Closes #93.

## Summary
- `.landing-hero__eyebrow` and `.landing-section__eyebrow` drop the `uppercase + 0.32em letter-spacing + 12px font-size` recipe — that's the Lovable / Bolt / v0.dev AI-template default. Switch to `var(--font-display)` italic 500, natural case, no tracking, larger size (`clamp(17px, 1.5vw, 20px)` hero / `clamp(16px, 1.4vw, 19px)` section).
- Hero copy: `SAGE — HEALTHY EATING, TRACKED SIMPLY` → `Healthy eating, tracked simply.` Drops the redundant brand prefix.
- Section eyebrows: `Track` / `Cook` / `Coach` → `Track.` / `Cook.` / `Coach.` Period gives editorial weight to single-word eyebrows.
- No new font — Cormorant Garamond was already imported in v0.6.22.

## Test plan
- [ ] Visit `/` — hero eyebrow now reads `Healthy eating, tracked simply.` in italic Cormorant Garamond, normal case, primary color.
- [ ] Scroll to Track / Cook / Coach sections — each eyebrow reads `Track.` / `Cook.` / `Coach.` in italic Cormorant.
- [ ] No more all-caps tracked-out type anywhere on the landing page above the fold.
- [ ] Other pages (dashboard, recipes, login) unchanged — only landing eyebrows touched.