### PR TITLE
feat: dashboard secondary modules — week/streak, tonight, coach (v0.6.25)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.25] - 2026-05-03 — Dashboard: This week + Streak + For tonight + Coach corner (closes #97)
+
+### Added
+- **This week / Streak** asymmetric split row (`2fr / 1fr`) below the existing meals/empty-day section.
+  - This week: compact 7-row weekly chart with sage gradient bars, today's row highlighted in `--color-mint-bg`, empty days show a dashed transparent track. Uses the existing `DiaryService.getWeeklySummary` snapshot.
+  - Streak: italic Cormorant `<loggedDays> / 7` display number with a count-up animation, plus a row of 7 dots showing which days were logged. The italic display number ties back to the brand wordmark voice instead of yet another bold sans number.
+- **For tonight** asymmetric recipe bento (`grid-template-columns: 2fr 1fr 1fr`). Picks 3 recipes via `RecipeService.getFeatured(3)`. The lead card shows a larger emoji cover + difficulty meta; the two trailing cards are compact. Avoids the taste-skill "3 equal cards in a row" ban via the asymmetric grid. Cards reuse the existing `recipe-card__cover--*` tone gradients so dark mode flips automatically.
+- **Coach corner**: latest conversation partner via `MessageService.getConversationPartners(userId).firstOrNull()` — initials disc + name + role + truncated last message + Reply CTA. Empty-state variant when the user has no conversations yet, inviting them to open Messages.
+
+### Changed
+- `DashboardRoutes.kt` enriched: computes `weekly` (Mon–Sun calorie ladder with `pct`/`isToday`/`isLogged` flags), `loggedDays` count, `featured` (3 top recipes from `RecipeService`), and `latestPartner` (first conversation in the user's inbox).
+
+### Implementation notes
+- Mobile breakpoints: at `≤960px` the week/streak split collapses to a single column and the recipe bento goes to 2 columns with the lead card spanning both. At `≤600px` everything stacks to single column and the coach Reply button moves below the message.
+- All numbers use `var(--font-mono)` + `tabular-nums` (week chart values) or italic Cormorant (streak count) — no Plus Jakarta Sans bold for data.
+
+---
+
 ## [v0.6.24] - 2026-05-03 — Unify all logos to one oil-paint look, visible at small sizes too (closes #95)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
@@ -4,6 +4,7 @@ import com.goodfood.config.UserSession
 import com.goodfood.config.model
 import com.goodfood.goals.GoalService
 import com.goodfood.messages.MessageService
+import com.goodfood.recipes.RecipeService
 import com.goodfood.util.fmt
 import io.ktor.server.application.*
 import io.ktor.server.response.*
@@ -51,6 +52,43 @@ fun Route.dashboardRoutes() {
         val goalCarb = goals?.get("carbs") ?: BigDecimal("250")
         val goalFat = goals?.get("fat") ?: BigDecimal("65")
         val isDayEmpty = entries.isEmpty()
+
+        // Below-the-fold dashboard modules (v0.6.25): weekly summary, streak,
+        // featured recipes, and the most recent coaching conversation.
+        val monday = today.minusDays(today.dayOfWeek.value.toLong() - 1)
+        val weeklyRaw = DiaryService.getWeeklySummary(session.userId, monday)
+        val goalCalDouble = goalCal.toDouble()
+        val weekly = weeklyRaw.map { w ->
+            val calsRaw = w["calories"] as BigDecimal
+            val cals = calsRaw.toDouble()
+            val rowDate = w["date"] as LocalDate
+            mapOf(
+                "dayName" to (w["dayName"] ?: ""),
+                "calories" to calsRaw.fmt(0),
+                "pct" to if (goalCalDouble > 0) ((cals / goalCalDouble) * 100).coerceAtMost(100.0).toInt() else 0,
+                "isToday" to (rowDate == today),
+                "isLogged" to (cals > 0)
+            )
+        }
+        val loggedDays = weekly.count { it["isLogged"] == true }
+
+        val featured = RecipeService.getFeatured(3).map { r ->
+            mapOf(
+                "id" to (r["id"] ?: 0),
+                "title" to (r["title"] ?: ""),
+                "coverEmoji" to (r["coverEmoji"] ?: "🍽️"),
+                "coverTone" to (r["coverTone"] ?: "sage"),
+                "avgRating" to (r["avgRating"] as BigDecimal).fmt(1),
+                "reviewCount" to (r["reviewCount"] as Int),
+                "calPerServing" to ((r["calPerServing"] as BigDecimal?) ?: BigDecimal.ZERO).fmt(0),
+                "totalTime" to (r["totalTime"] as Int),
+                "difficulty" to (r["difficulty"] ?: "easy")
+            )
+        }
+
+        val partners = MessageService.getConversationPartners(session.userId)
+        val latestPartner = partners.firstOrNull()
+
         call.respond(ThymeleafContent("subscriber/dashboard", model(
             "session" to session, "date" to today.format(DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy")), "meals" to meals,
             "isDayEmpty" to isDayEmpty,
@@ -66,6 +104,8 @@ fun Route.dashboardRoutes() {
             "pctProtein" to pct(summary["protein"]!!, goalProt),
             "pctCarbs" to pct(summary["carbs"]!!, goalCarb),
             "pctFat" to pct(summary["fat"]!!, goalFat),
+            "weekly" to weekly, "loggedDays" to loggedDays,
+            "featured" to featured, "latestPartner" to latestPartner,
             "unreadMessages" to unread, "activePage" to "dashboard")))
     }
 }

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2956,6 +2956,293 @@ input::placeholder, textarea::placeholder {
 }
 
 /* ============================================================
+   Dashboard secondary modules — appended below the nutrition card.
+   This week + Streak (asymmetric split), For tonight (recipe bento),
+   Coach corner (latest message preview).
+   ============================================================ */
+.dashboard-row {
+    display: grid;
+    gap: 24px;
+    margin-bottom: 24px;
+}
+.dashboard-row--weekstreak { grid-template-columns: 2fr 1fr; }
+
+.dashboard-card__head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+.dashboard-card__head--bare {
+    margin-bottom: 24px;
+    padding: 0 4px;
+}
+.dashboard-card__link {
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+    text-decoration: none;
+    font-weight: 500;
+    letter-spacing: var(--tracking-snug);
+}
+.dashboard-card__link:hover {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+/* ---- This week mini chart ---- */
+.dashboard-week__chart {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.dashboard-week__row {
+    display: grid;
+    grid-template-columns: 38px 1fr 70px;
+    align-items: center;
+    gap: 14px;
+    padding: 8px 12px;
+    margin: 0 -12px;
+    border-radius: var(--radius-sm);
+    transition: background var(--dur-fast) var(--ease);
+}
+.dashboard-week__row.is-today { background: var(--color-mint-bg); }
+.dashboard-week__day {
+    font-size: var(--text-xs);
+    color: var(--text-soft);
+    font-weight: 600;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+}
+.dashboard-week__row.is-today .dashboard-week__day {
+    color: var(--color-sage-deep);
+    font-weight: 700;
+}
+.dashboard-week__bar {
+    height: 8px;
+    background: var(--color-progress-track);
+    border-radius: var(--radius-pill);
+    overflow: hidden;
+}
+.dashboard-week__row.is-empty .dashboard-week__bar {
+    background: transparent;
+    border: 1px dashed var(--color-border);
+    height: 6px;
+}
+.dashboard-week__bar > span {
+    display: block;
+    height: 100%;
+    width: var(--pct, 0%);
+    background: linear-gradient(90deg, var(--color-sage-deep), var(--color-sage));
+    border-radius: inherit;
+    transform-origin: left center;
+}
+.dashboard-week__val {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-strong);
+    text-align: right;
+}
+.dashboard-week__row.is-empty .dashboard-week__val { color: var(--color-faint); font-weight: 500; }
+
+/* ---- Streak ---- */
+.dashboard-streak {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 100%;
+}
+.dashboard-streak__num {
+    margin: 8px 0 0;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-weight: 600;
+    line-height: 0.95;
+    letter-spacing: -0.02em;
+    color: var(--text-soft);
+}
+.dashboard-streak__num strong {
+    color: var(--color-primary);
+    font-weight: 700;
+    font-size: clamp(72px, 8vw, 96px);
+    margin-right: 8px;
+}
+.dashboard-streak__total {
+    font-size: clamp(28px, 3vw, 36px);
+    color: var(--text-soft);
+}
+.dashboard-streak__caption {
+    margin: 14px 0 0;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+    line-height: 1.4;
+}
+.dashboard-streak__dots {
+    display: flex;
+    gap: 8px;
+    margin-top: auto;
+    padding-top: 24px;
+}
+.dashboard-streak__dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-progress-track);
+    transition: background var(--dur-fast) var(--ease);
+}
+.dashboard-streak__dot.is-on {
+    background: linear-gradient(135deg, var(--color-sage-deep), var(--color-sage));
+}
+
+/* ---- For tonight (asymmetric recipe bento) ---- */
+.dashboard-tonight { margin-bottom: 24px; }
+.dashboard-tonight__grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr;
+    gap: 16px;
+    align-items: stretch;
+}
+.dashboard-tonight__card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
+    display: flex;
+    flex-direction: column;
+}
+.dashboard-tonight__card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
+}
+.dashboard-tonight__link {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    text-decoration: none;
+    color: inherit;
+}
+.dashboard-tonight__link:hover { text-decoration: none; }
+.dashboard-tonight__cover {
+    aspect-ratio: 16 / 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft));
+}
+.dashboard-tonight__cover--small { aspect-ratio: 16 / 9; }
+.dashboard-tonight__emoji {
+    font-size: 56px;
+    line-height: 1;
+    filter: var(--emoji-shadow);
+}
+.dashboard-tonight__card--lead .dashboard-tonight__emoji { font-size: 88px; }
+.dashboard-tonight__rating {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: var(--overlay-strong);
+    color: var(--color-cream);
+    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    font-size: var(--text-xs);
+    font-weight: 700;
+    letter-spacing: var(--tracking-snug);
+}
+.dashboard-tonight__body {
+    padding: 14px 18px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.dashboard-tonight__title {
+    margin: 0;
+    font-size: var(--text-base);
+    font-weight: 700;
+    color: var(--text-strong);
+    line-height: var(--leading-snug);
+}
+.dashboard-tonight__card--lead .dashboard-tonight__title {
+    font-size: var(--text-lg);
+}
+.dashboard-tonight__meta {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+}
+.dashboard-tonight__diff { text-transform: capitalize; }
+
+/* ---- Coach corner ---- */
+.dashboard-coach { margin-bottom: 24px; }
+.dashboard-coach__body {
+    display: grid;
+    grid-template-columns: 60px 1fr auto;
+    gap: 18px;
+    align-items: center;
+}
+.dashboard-coach__avatar {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: var(--text-lg);
+    letter-spacing: -0.02em;
+}
+.dashboard-coach__from {
+    margin: 0 0 6px;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+}
+.dashboard-coach__from strong {
+    color: var(--text-strong);
+    font-weight: 700;
+    margin-right: 8px;
+    font-size: var(--text-base);
+}
+.dashboard-coach__role {
+    font-size: var(--text-xs);
+    text-transform: capitalize;
+    color: var(--color-primary);
+    letter-spacing: var(--tracking-snug);
+    font-weight: 600;
+}
+.dashboard-coach__msg {
+    margin: 0;
+    color: var(--text-strong);
+    font-size: var(--text-base);
+    line-height: 1.45;
+}
+.dashboard-coach__cta { white-space: nowrap; }
+.dashboard-coach--empty .dashboard-coach__empty-text {
+    margin: 0 0 16px;
+    color: var(--text-soft);
+    line-height: 1.55;
+    max-width: 60ch;
+}
+
+/* ---- Dashboard module responsive ---- */
+@media (max-width: 960px) {
+    .dashboard-row--weekstreak { grid-template-columns: 1fr; }
+    .dashboard-tonight__grid { grid-template-columns: 1fr 1fr; }
+    .dashboard-tonight__card--lead { grid-column: span 2; }
+}
+@media (max-width: 600px) {
+    .dashboard-tonight__grid { grid-template-columns: 1fr; }
+    .dashboard-tonight__card--lead { grid-column: auto; }
+    .dashboard-coach__body { grid-template-columns: 60px 1fr; }
+    .dashboard-coach__cta { grid-column: 1 / -1; }
+}
+
+/* ============================================================
    Responsive
    ============================================================ */
 @media (max-width: 1024px) {

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -110,6 +110,114 @@
             </ul>
             <p class="empty-hint" th:if="${meal.entries == null or meal.entries.isEmpty()}">Nothing here yet.</p>
         </section>
+
+        <!-- ========== This week + Streak (asymmetric split) ========== -->
+        <section class="dashboard-row dashboard-row--weekstreak">
+            <article class="card dashboard-week">
+                <header class="dashboard-card__head">
+                    <h2 class="section-title">This week</h2>
+                    <a th:href="'/goals'" class="dashboard-card__link">Set goals →</a>
+                </header>
+                <div class="dashboard-week__chart">
+                    <div class="dashboard-week__row" th:each="w, iter : ${weekly}"
+                         th:classappend="${w.isToday} ? ' is-today' : (${w.isLogged} ? '' : ' is-empty')"
+                         th:style="|--pct: ${w.pct}%; --i: ${iter.index}|">
+                        <span class="dashboard-week__day" th:text="${w.dayName}">Mon</span>
+                        <div class="dashboard-week__bar"><span></span></div>
+                        <span class="dashboard-week__val" th:text="${w.calories}">0</span>
+                    </div>
+                </div>
+            </article>
+            <article class="card dashboard-streak">
+                <header class="dashboard-card__head">
+                    <h2 class="section-title">Streak</h2>
+                </header>
+                <p class="dashboard-streak__num">
+                    <strong th:text="${loggedDays}" data-count-up>0</strong>
+                    <span class="dashboard-streak__total">/ 7</span>
+                </p>
+                <p class="dashboard-streak__caption">days logged this week.</p>
+                <div class="dashboard-streak__dots">
+                    <span class="dashboard-streak__dot" th:each="d : ${weekly}"
+                          th:classappend="${d.isLogged} ? ' is-on' : ''"
+                          th:title="${d.dayName}"></span>
+                </div>
+            </article>
+        </section>
+
+        <!-- ========== For tonight (asymmetric recipe bento) ========== -->
+        <section class="dashboard-tonight" th:if="${featured != null and !featured.isEmpty()}">
+            <header class="dashboard-card__head dashboard-card__head--bare">
+                <h2 class="section-title">For tonight</h2>
+                <a th:href="'/recipes'" class="dashboard-card__link">Browse all →</a>
+            </header>
+            <div class="dashboard-tonight__grid">
+                <article class="dashboard-tonight__card dashboard-tonight__card--lead"
+                         th:if="${featured.size() > 0}" th:with="f=${featured[0]}"
+                         style="--i: 0">
+                    <a th:href="|/recipes/${f.id}|" class="dashboard-tonight__link">
+                        <div th:classappend="|recipe-card__cover--${f.coverTone}|"
+                             class="dashboard-tonight__cover">
+                            <span class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
+                            <span class="dashboard-tonight__rating" th:if="${f.reviewCount > 0}">★ <span th:text="${f.avgRating}">0</span></span>
+                        </div>
+                        <div class="dashboard-tonight__body">
+                            <h3 class="dashboard-tonight__title" th:text="${f.title}">Recipe</h3>
+                            <p class="dashboard-tonight__meta">
+                                <span th:text="${f.calPerServing}">320</span> kcal ·
+                                <span th:text="${f.totalTime}">30</span> min ·
+                                <span th:text="${f.difficulty}" class="dashboard-tonight__diff">easy</span>
+                            </p>
+                        </div>
+                    </a>
+                </article>
+                <article class="dashboard-tonight__card"
+                         th:each="f, iter : ${featured}" th:if="${iter.index > 0}"
+                         th:style="|--i: ${iter.index}|">
+                    <a th:href="|/recipes/${f.id}|" class="dashboard-tonight__link">
+                        <div th:classappend="|recipe-card__cover--${f.coverTone}|"
+                             class="dashboard-tonight__cover dashboard-tonight__cover--small">
+                            <span class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
+                        </div>
+                        <div class="dashboard-tonight__body">
+                            <h3 class="dashboard-tonight__title" th:text="${f.title}">Recipe</h3>
+                            <p class="dashboard-tonight__meta">
+                                <span th:text="${f.calPerServing}">320</span> kcal ·
+                                <span th:text="${f.totalTime}">30</span> min
+                            </p>
+                        </div>
+                    </a>
+                </article>
+            </div>
+        </section>
+
+        <!-- ========== Coach corner ========== -->
+        <section class="card dashboard-coach" th:if="${latestPartner != null}">
+            <header class="dashboard-card__head">
+                <h2 class="section-title">From your coach</h2>
+                <a th:href="'/messages'" class="dashboard-card__link">All messages →</a>
+            </header>
+            <div class="dashboard-coach__body">
+                <div class="dashboard-coach__avatar" th:text="${latestPartner.partnerInitials}">SW</div>
+                <div class="dashboard-coach__content">
+                    <p class="dashboard-coach__from">
+                        <strong th:text="${latestPartner.partnerName}">Dr. Sarah Williams</strong>
+                        <span class="dashboard-coach__role" th:text="${latestPartner.partnerRole}">nutritionist</span>
+                    </p>
+                    <p class="dashboard-coach__msg" th:text="${latestPartner.lastMessage}">…</p>
+                </div>
+                <a th:href="|/messages/${latestPartner.partnerId}|" class="btn btn--primary dashboard-coach__cta">Reply</a>
+            </div>
+        </section>
+        <section class="card dashboard-coach dashboard-coach--empty" th:if="${latestPartner == null}">
+            <header class="dashboard-card__head">
+                <h2 class="section-title">A coach on call</h2>
+            </header>
+            <p class="dashboard-coach__empty-text">
+                Direct-message a registered nutritionist about a goal, a binge, or what to eat tonight. They reply in their actual voice.
+            </p>
+            <a th:href="'/messages'" class="btn btn--primary">Open messages</a>
+        </section>
     </main>
 </div>
 <script th:src="'/static/js/app.js'" src="/static/js/app.js"></script>


### PR DESCRIPTION
Closes #97.

## Summary
Three new modules below the nutrition card so `/dashboard` doesn't feel empty:

1. **This week + Streak** — asymmetric `2fr / 1fr` split row.
   - This week: compact 7-row weekly chart, sage gradient bars, today's row in mint pill, empty days dashed.
   - Streak: big italic Cormorant `<N> / 7` (count-up animated) + 7 dots showing which days were logged. Italic display number ties to the brand wordmark voice.
2. **For tonight** — asymmetric `2fr / 1fr / 1fr` recipe bento with `RecipeService.getFeatured(3)`. Lead card has bigger cover + difficulty; trailing cards compact. Avoids taste-skill's "3 equal cards in a row" ban.
3. **Coach corner** — latest conversation partner via `MessageService.getConversationPartners(userId).firstOrNull()`. Initials disc + name + role + last-message preview + Reply CTA. Empty-state variant when the user has no conversations yet.

## taste-skill compliance
- `DESIGN_VARIANCE 8`: every row uses asymmetric grid (`2fr/1fr`, `2fr/1fr/1fr`), no centered or 3-equal-card layouts.
- `MOTION_INTENSITY 6`: streak uses count-up; weekly bars inherit the `bar-grow` keyframe staggered by `--i`. All gated behind `prefers-reduced-motion: no-preference`.
- `VISUAL_DENSITY 4`: cards retain breathing room; numbers use mono / italic display, never sans-bold.
- Anti-emoji: only used for recipe cover fallbacks (existing pattern, content-coded), not brand UI.

## Reuse / no new tokens
All new modules use existing CSS tokens (`--color-sage-deep/sage`, `--color-mint-bg`, `recipe-card__cover--*`, `--overlay-strong`, `--emoji-shadow`). Dark mode flips automatically via the v0.6.14 token work — zero extra dark-mode CSS.

## Test plan
- [ ] Visit `/dashboard` — three new sections render below the nutrition card.
- [ ] Today's row in the mini week chart has the mint background pill.
- [ ] Streak counts the right number of logged days; dots align with which days had calories > 0.
- [ ] For tonight shows 3 featured recipes; clicking the lead card → recipe detail.
- [ ] Coach corner shows the most recent conversation; Reply button → `/messages/<partnerId>`.
- [ ] If the user has no conversations, the empty-state variant shows with "Open messages" CTA.
- [ ] Toggle dark mode — every module reads correctly (gradients, dots, mint pill, recipe covers).
- [ ] Resize ≤960px — week/streak stacks; recipe bento goes 2-col with lead spanning both.
- [ ] Resize ≤600px — all modules collapse to single column.