### PR TITLE
feat: messages page Telegram-style polish + smooth interactions (v0.6.26)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.26] - 2026-05-03 — Messages: Telegram-style polish + smooth interactions (closes #99)
+
+### Added (visual)
+- **Sticky chat header** with partner avatar + name + role + "Active recently" status line. Replaces the bare strip that just showed a name.
+- **Search input** at the top of the conversation list — JS-side `data-name` substring filter on `[.conv-list__row]`, with an empty-state hint when no rows match.
+- **Bubble tails** — small CSS pseudo-element triangles pointing to the sender's bottom corner (Telegram signature). No extra SVG; pure `clip-path: polygon(...)`.
+- **Date separators** — sticky `Today / Yesterday / Monday / MMM d, yyyy` pills between message clusters. `MessageRoutes` groups the conversation list by `sentDate`; the template renders `[.chat-day][.chat-day__sep]` blocks. Pills sit on `var(--overlay-strong)` and stick at `top: 8px` while scrolling.
+- **Online dots** on every avatar — small mint disc with a 2px disc-coloured border so it reads cleanly on hover/active states. (Visual cue only — no presence tracking.)
+- **Dotted wallpaper** in the chat-scroll background: `radial-gradient(circle at 1px 1px, ...) 22px 22px` over the existing chat gradient, like Telegram's wallpaper layer.
+- **Round pill composer input** + **circular filled send button** with paper-plane SVG. Replaces the rectangular textarea + button combo.
+- **Active conversation** in the list now flips to the sage-primary background with cream text and an inverted avatar; the unread pill flips colors too. More legible than the previous subtle tint.
+
+### Added (smooth interactions, all in `initChatPage()` in `app.js`)
+- **Auto-scroll to bottom** on page load (no smooth, instant — avoids the visible top-then-jump).
+- **Auto-resize composer textarea** as the user types (1 row → up to 140px, capped).
+- **Send on Enter** (`Shift+Enter` newline). Send button disabled when input is empty.
+- **Optimistic AJAX submit** — `fetch(POST, FormData)` instead of native form submit. The bubble appends locally with a `bubble--pending` class showing "sending…" until the server response lands; on failure it flips to `bubble--failed`. Page no longer reloads on send. The optimistic bubble lives inside the latest `.chat-day` group, or creates a fresh "Today" group if the thread was empty.
+- **Composer auto-focus** on page load so a returning user can just start typing.
+
+### Changed
+- `MessageService.getConversation` now returns `sentDate` (`LocalDate`) and `sentTime` (`HH:mm`) per message in addition to the existing `sentAt` formatted string. Used by the date-grouper and the new bubble timestamps.
+- `MessageRoutes` exposes `conversationGroups` (date-grouped) + `activePartnerRole` to both subscriber and professional templates.
+
+### Implementation notes
+- All polish reuses existing tokens: `--color-primary`, `--bubble-them-bg`, `--overlay-strong`, `--color-mint`, `--color-cream`. Dark mode flips automatically — no separate dark CSS.
+- Date-group separator pill takes `--overlay-strong` (forest in light, near-black in dark) which already adapts.
+- `requestSubmit()` triggers the form's submit handler so all the AJAX logic stays on `submit`, not an explicit button click — keyboard users (Enter) and mouse users hit the same code path.
+- Sticky header uses `position: sticky; top: 0` inside the chat-main flex column. Chat-day separators stick within the scroll container.
+
+### Subscriber + Professional both updated
+- `subscriber/messages.html` and `professional/messages.html` both refactored to the same new structure. Two slightly different copy strings ("Search…" vs "Search clients…", empty-state copy) preserved.
+
+---
+
 ## [v0.6.25] - 2026-05-03 — Dashboard: This week + Streak + For tonight + Coach corner (closes #97)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
@@ -10,6 +10,31 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.thymeleaf.*
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Group a flat conversation list by `sentDate`, labelling each group as
+ * "Today" / "Yesterday" / day-of-week (within the last 6 days) / "MMM d, yyyy".
+ * Returns a list of `{label, messages}` maps so the template can render
+ * sticky date pills between message clusters (Telegram-style).
+ */
+private fun groupByDate(conversation: List<Map<String, Any>>, today: LocalDate): List<Map<String, Any>> {
+    if (conversation.isEmpty()) return emptyList()
+    val dayOfWeekFmt = DateTimeFormatter.ofPattern("EEEE")
+    val absoluteFmt = DateTimeFormatter.ofPattern("MMM d, yyyy")
+    return conversation.groupBy { it["sentDate"] as LocalDate }
+        .toSortedMap()
+        .map { (date, msgs) ->
+            val label = when {
+                date == today -> "Today"
+                date == today.minusDays(1) -> "Yesterday"
+                date.isAfter(today.minusDays(7)) -> date.format(dayOfWeekFmt)
+                else -> date.format(absoluteFmt)
+            }
+            mapOf("label" to label, "messages" to msgs)
+        }
+}
 
 fun Route.messageRoutes() {
     get("/messages") {
@@ -18,11 +43,14 @@ fun Route.messageRoutes() {
         val unread = MessageService.getUnreadCount(session.userId)
         val firstPartner = partners.firstOrNull(); val firstPartnerId = firstPartner?.get("partnerId") as? Int
         val conversation = if (firstPartnerId != null) MessageService.getConversation(session.userId, firstPartnerId) else emptyList()
+        val groups = groupByDate(conversation, LocalDate.now())
         val template = if (session.role == "professional") "professional/messages" else "subscriber/messages"
         call.respond(ThymeleafContent(template, model(
-            "session" to session, "partners" to partners, "conversation" to conversation,
+            "session" to session, "partners" to partners,
+            "conversation" to conversation, "conversationGroups" to groups,
             "activePartnerId" to firstPartnerId, "activePartnerName" to (firstPartner?.get("partnerName") ?: ""),
             "activePartnerInitials" to (firstPartner?.get("partnerInitials") ?: ""),
+            "activePartnerRole" to (firstPartner?.get("partnerRole") ?: ""),
             "unreadMessages" to unread, "activePage" to "messages")))
     }
 
@@ -31,14 +59,18 @@ fun Route.messageRoutes() {
         val partnerId = call.parameters["partnerId"]?.toIntOrNull() ?: return@get call.respondRedirect("/messages")
         val partners = MessageService.getConversationPartners(session.userId)
         val conversation = MessageService.getConversation(session.userId, partnerId)
+        val groups = groupByDate(conversation, LocalDate.now())
         val partner = UserService.getById(partnerId)
         val unread = MessageService.getUnreadCount(session.userId)
         val pName = partner?.get(Users.fullName) ?: ""
         val pInitials = pName.split(" ").filter { it.isNotEmpty() }.map { it.first().uppercase() }.joinToString("")
+        val pRole = partner?.get(Users.role) ?: ""
         val template = if (session.role == "professional") "professional/messages" else "subscriber/messages"
         call.respond(ThymeleafContent(template, model(
-            "session" to session, "partners" to partners, "conversation" to conversation,
-            "activePartnerId" to partnerId, "activePartnerName" to pName, "activePartnerInitials" to pInitials,
+            "session" to session, "partners" to partners,
+            "conversation" to conversation, "conversationGroups" to groups,
+            "activePartnerId" to partnerId, "activePartnerName" to pName,
+            "activePartnerInitials" to pInitials, "activePartnerRole" to pRole,
             "unreadMessages" to unread, "activePage" to "messages")))
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
@@ -5,6 +5,7 @@ import com.goodfood.util.fmtChatTime
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * 1-on-1 messaging between subscribers and their professionals.
@@ -60,9 +61,12 @@ object MessageService {
             ((AdviceMessages.senderId eq userId) and (AdviceMessages.receiverId eq partnerId)) or
             ((AdviceMessages.senderId eq partnerId) and (AdviceMessages.receiverId eq userId))
         }.orderBy(AdviceMessages.sentAt).map { row ->
+            val ts = row[AdviceMessages.sentAt]
             mapOf("id" to row[AdviceMessages.id], "senderId" to row[AdviceMessages.senderId],
                 "message" to row[AdviceMessages.message],
-                "sentAt" to row[AdviceMessages.sentAt].fmtChatTime(),
+                "sentAt" to ts.fmtChatTime(),
+                "sentDate" to ts.toLocalDate(),
+                "sentTime" to ts.format(DateTimeFormatter.ofPattern("HH:mm")),
                 "isMine" to (row[AdviceMessages.senderId] == userId))
         }
     }

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -1918,63 +1918,131 @@ input::placeholder, textarea::placeholder {
 }
 
 /* ============================================================
-   Chat
+   Chat — Telegram-inspired layout. Sticky header, search-able
+   conversation list with online dots and unread pills, date-grouped
+   bubbles with a CSS-tail pointing to the sender corner, pill
+   composer with circular send button, dotted wallpaper background.
    ============================================================ */
 .chat-layout {
     display: grid;
-    grid-template-columns: minmax(220px, 320px) 1fr;
-    min-height: 520px;
+    grid-template-columns: minmax(260px, 340px) 1fr;
+    min-height: calc(100vh - 220px);
     background: var(--color-surface);
     border-radius: var(--radius-md);
     overflow: hidden;
     box-shadow: var(--shadow-sm);
 }
+
+/* ---- Conversation list (left rail) ---- */
 .chat-sidebar {
     border-right: 1px solid var(--color-border-soft);
     background: var(--color-surface-warm);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.chat-sidebar__head {
+    padding: 18px 20px 14px;
+    border-bottom: 1px solid var(--color-border-soft);
+    flex-shrink: 0;
 }
 .chat-sidebar__title {
-    margin: 0;
-    padding: 16px 20px;
+    margin: 0 0 12px;
     font-size: var(--text-xs);
     text-transform: uppercase;
     letter-spacing: var(--tracking-wide);
     color: var(--text-soft);
-    border-bottom: 1px solid var(--color-border-soft);
     font-weight: 700;
 }
+.chat-search {
+    width: 100%;
+    padding: 9px 14px;
+    border: 1px solid transparent;
+    border-radius: var(--radius-pill);
+    background: var(--color-surface);
+    font: inherit;
+    font-size: var(--text-sm);
+    color: var(--text-strong);
+    transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.chat-search:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    background: var(--color-bg-elevated);
+}
+.chat-search::placeholder { color: var(--text-soft); }
 
-.conv-list { list-style: none; margin: 0; padding: 0; }
+.conv-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    overflow-y: auto;
+    flex: 1;
+}
+.conv-list__row { margin: 0; }
+.conv-list__row.is-hidden { display: none; }
 .conv-list__item {
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 14px 20px;
+    padding: 12px 16px;
+    margin: 2px 8px;
     color: inherit;
     text-decoration: none;
-    border-bottom: 1px solid var(--color-border-soft);
-    transition: background var(--dur-fast) var(--ease);
+    border-radius: var(--radius-md);
+    transition: background var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease);
+    position: relative;
 }
 .conv-list__item:hover {
     background: var(--color-surface);
     text-decoration: none;
+    transform: translateX(2px);
 }
-.conv-list__item--active {
-    background: var(--conv-active-bg);
+.conv-list__item--active,
+.conv-list__item--active:hover {
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    transform: none;
+}
+.conv-list__item--active .conv-list__name,
+.conv-list__item--active .conv-list__preview { color: var(--color-primary-on); }
+.conv-list__item--active .conv-list__avatar {
+    background: var(--color-primary-on);
+    color: var(--color-primary);
 }
 
 .conv-list__avatar {
-    width: 40px;
-    height: 40px;
+    position: relative;
+    width: 44px;
+    height: 44px;
     border-radius: var(--radius-pill);
     background: var(--color-primary);
     color: var(--color-primary-on);
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     font-size: var(--text-sm);
     font-weight: 700;
     flex-shrink: 0;
+    letter-spacing: -0.02em;
+}
+.conv-list__avatar--lg {
+    width: 44px;
+    height: 44px;
+    font-size: var(--text-base);
+}
+.conv-list__online {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--color-mint);
+    border: 2px solid var(--color-surface-warm);
+}
+.conv-list__item--active .conv-list__online {
+    border-color: var(--color-primary);
 }
 
 .conv-list__body {
@@ -1982,10 +2050,15 @@ input::placeholder, textarea::placeholder {
     min-width: 0;
     display: flex;
     flex-direction: column;
+    gap: 2px;
 }
 .conv-list__name {
     font-weight: 600;
     font-size: var(--text-body);
+    color: var(--text-strong);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .conv-list__preview {
     font-size: var(--text-xs);
@@ -1994,85 +2067,248 @@ input::placeholder, textarea::placeholder {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+.conv-list__unread {
+    flex-shrink: 0;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 7px;
+    border-radius: var(--radius-pill);
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    font-size: 11px;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    letter-spacing: -0.02em;
+}
+.conv-list__item--active .conv-list__unread {
+    background: var(--color-primary-on);
+    color: var(--color-primary);
+}
 
+/* ---- Main chat panel ---- */
 .chat-main {
     display: flex;
     flex-direction: column;
-    min-height: 520px;
+    min-height: 0;
     background: var(--color-surface);
 }
 .chat-main__head {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
+    gap: 14px;
+    padding: 14px 22px;
     border-bottom: 1px solid var(--color-border-soft);
     background: var(--color-surface);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    backdrop-filter: saturate(140%);
+    flex-shrink: 0;
 }
-.chat-main__head--empty { justify-content: center; }
+.chat-main__head--empty {
+    justify-content: center;
+    min-height: 72px;
+}
+.chat-main__head-body {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
 .chat-main__title {
     margin: 0;
-    font-size: var(--text-lg);
+    font-size: var(--text-base);
     font-weight: 700;
     letter-spacing: var(--tracking-snug);
+    color: var(--text-strong);
 }
+.chat-main__subtitle {
+    margin: 0;
+    font-size: var(--text-xs);
+    color: var(--text-soft);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.chat-main__role { text-transform: capitalize; }
+.chat-main__status { color: var(--color-sage-deep); font-weight: 500; }
+.chat-main__sep { opacity: 0.4; }
 
+/* ---- Message area: dotted wallpaper background ---- */
 .chat-scroll {
     flex: 1;
     overflow-y: auto;
-    padding: 20px;
+    padding: 20px 24px 24px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    background: linear-gradient(180deg, var(--chat-bg-grad-from) 0%, var(--chat-bg-grad-to) 100%);
+    gap: 4px;
+    background:
+        radial-gradient(circle at 1px 1px, var(--color-border-soft) 1px, transparent 0) 0 0 / 22px 22px,
+        linear-gradient(180deg, var(--chat-bg-grad-from) 0%, var(--chat-bg-grad-to) 100%);
+    scroll-behavior: smooth;
 }
 
+/* Date separator pill — sticks to the top while scrolling through that day's
+   messages, Telegram-style */
+.chat-day { display: contents; }
+.chat-day__sep {
+    align-self: center;
+    position: sticky;
+    top: 8px;
+    z-index: 2;
+    margin: 12px 0 8px;
+    padding: 4px 14px;
+    background: var(--overlay-strong);
+    color: var(--color-cream);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: var(--tracking-snug);
+    border-radius: var(--radius-pill);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+}
+
+/* ---- Bubbles with CSS tails ---- */
 .bubble {
-    max-width: 75%;
-    padding: 12px 16px;
-    border-radius: var(--radius-md);
+    max-width: 72%;
+    padding: 9px 14px 6px;
+    border-radius: 18px;
     font-size: var(--text-body);
-    animation: bubble-in var(--dur) var(--ease-out) both;
+    animation: bubble-in 0.3s var(--ease-out) both;
+    position: relative;
+    margin-bottom: 4px;
 }
 .bubble--mine {
     align-self: flex-end;
     background: var(--color-primary);
     color: var(--color-primary-on);
-    border-bottom-right-radius: 4px;
-    box-shadow: 0 2px 8px rgba(94, 125, 79, 0.20);
+    border-bottom-right-radius: 6px;
+    box-shadow: 0 1px 2px rgba(31, 42, 35, 0.10);
 }
 .bubble--theirs {
     align-self: flex-start;
     background: var(--bubble-them-bg);
-    color: var(--text);
-    border-bottom-left-radius: 4px;
+    color: var(--text-strong);
+    border-bottom-left-radius: 6px;
+    box-shadow: 0 1px 2px rgba(31, 42, 35, 0.06);
+}
+/* Pseudo-element tails — small triangles pointing to the sender corner */
+.bubble--mine::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    right: -6px;
+    width: 12px;
+    height: 12px;
+    background: var(--color-primary);
+    clip-path: polygon(0 0, 0 100%, 100% 100%);
+    border-bottom-right-radius: 2px;
+}
+.bubble--theirs::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: -6px;
+    width: 12px;
+    height: 12px;
+    background: var(--bubble-them-bg);
+    clip-path: polygon(100% 0, 100% 100%, 0 100%);
+    border-bottom-left-radius: 2px;
 }
 .bubble__text {
-    margin: 0 0 4px;
+    margin: 0;
     white-space: pre-wrap;
     word-break: break-word;
     line-height: var(--leading-snug);
 }
 .bubble__time {
+    margin-top: 2px;
     font-size: 11px;
-    opacity: 0.75;
-    display: block;
     font-weight: 500;
+    display: inline-block;
+    margin-left: 8px;
+    float: right;
+    line-height: 1.6;
+}
+.bubble--mine .bubble__time { color: rgba(251, 248, 240, 0.72); }
+.bubble--theirs .bubble__time { color: var(--text-soft); }
+
+/* Optimistic bubble while AJAX send is in flight */
+.bubble--pending { opacity: 0.55; }
+.bubble--pending .bubble__time::after {
+    content: " · sending…";
+    font-style: italic;
+}
+.bubble--failed {
+    opacity: 1;
+    outline: 1px solid var(--color-danger);
+}
+.bubble--failed .bubble__time::after {
+    content: " · failed — tap to retry";
+    color: var(--color-danger);
+    font-weight: 600;
 }
 
+/* ---- Composer: pill input + circular filled send button ---- */
 .chat-compose {
     display: flex;
-    gap: 12px;
-    padding: 16px 20px;
+    gap: 10px;
+    padding: 14px 20px;
     border-top: 1px solid var(--color-border-soft);
     align-items: flex-end;
     background: var(--color-surface);
+    flex-shrink: 0;
 }
-.chat-compose textarea {
+.chat-compose__input {
     flex: 1;
-    resize: vertical;
-    min-height: 44px;
-    max-height: 160px;
+    resize: none;
+    min-height: 42px;
+    max-height: 140px;
+    padding: 10px 18px;
+    border: 1px solid var(--color-border);
+    border-radius: 22px;
+    background: var(--color-surface-warm);
+    color: var(--text-strong);
+    font: inherit;
+    font-size: var(--text-body);
+    line-height: 1.4;
+    transition: border-color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease);
+}
+.chat-compose__input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    background: var(--color-surface);
+}
+.chat-compose__send {
+    width: 42px;
+    height: 42px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 50%;
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
+    box-shadow: 0 2px 8px rgba(31, 42, 35, 0.10);
+}
+.chat-compose__send:hover:not(:disabled) {
+    background: var(--color-primary-hover);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow);
+}
+.chat-compose__send:active:not(:disabled) { transform: translateY(0); }
+.chat-compose__send:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+.chat-compose__send svg {
+    margin-left: -2px;  /* visually centre the asymmetric paper-plane glyph */
 }
 
 @keyframes bubble-in {

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -271,6 +271,132 @@
         });
     }
 
+    /* ---- Chat: scroll-to-bottom on load, auto-resize composer, send-on-Enter,
+           optimistic AJAX submit, conversation list filter. Telegram-style. ---- */
+    function initChatPage() {
+        var scrollEl = document.querySelector(".js-chat-scroll");
+        var compose  = document.querySelector(".js-chat-compose");
+        var input    = document.querySelector(".js-chat-input");
+        var sendBtn  = document.querySelector(".js-chat-send");
+        var filterEl = document.querySelector(".js-conv-filter");
+
+        // 1. Scroll the message log to the bottom on first paint so the latest
+        //    message is visible without manual scrolling. Use scrollTop directly
+        //    (instant) instead of smooth — smooth scroll runs after paint and
+        //    flickers from top.
+        if (scrollEl) {
+            scrollEl.scrollTop = scrollEl.scrollHeight;
+        }
+
+        // 2. Composer: auto-grow textarea + enable send button when there's
+        //    content + send-on-Enter (Shift+Enter newline).
+        if (input && compose) {
+            function syncSendDisabled() {
+                if (sendBtn) sendBtn.disabled = input.value.trim().length === 0;
+            }
+            function autosize() {
+                input.style.height = "auto";
+                input.style.height = Math.min(input.scrollHeight, 140) + "px";
+            }
+            input.addEventListener("input", function () { autosize(); syncSendDisabled(); });
+            input.addEventListener("keydown", function (e) {
+                if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+                    e.preventDefault();
+                    if (!sendBtn.disabled) compose.requestSubmit();
+                }
+            });
+            // Focus when the page lands so a returning user can just type.
+            input.focus();
+            syncSendDisabled();
+
+            // 3. Optimistic AJAX submit: append the bubble locally, fire-and-forget
+            //    the POST. The route still 302-redirects; we ignore the body and
+            //    rely on the next navigation (or a manual refresh) to reconcile
+            //    server state. Keeps the UI feeling instant.
+            compose.addEventListener("submit", function (e) {
+                if (sendBtn.disabled) { e.preventDefault(); return; }
+                var text = input.value.trim();
+                if (!text) { e.preventDefault(); return; }
+                e.preventDefault();
+                appendOptimisticBubble(scrollEl, text);
+                input.value = "";
+                autosize();
+                syncSendDisabled();
+
+                var fd = new FormData(compose);
+                fetch(compose.action, { method: "POST", body: fd, redirect: "manual" })
+                    .then(function () {
+                        // Mark the optimistic bubble as confirmed (drops the
+                        // "sending…" annotation); leave it in place.
+                        var pending = scrollEl.querySelector(".bubble--pending");
+                        if (pending) pending.classList.remove("bubble--pending");
+                    })
+                    .catch(function () {
+                        var pending = scrollEl.querySelector(".bubble--pending");
+                        if (pending) {
+                            pending.classList.remove("bubble--pending");
+                            pending.classList.add("bubble--failed");
+                        }
+                    });
+            });
+        }
+
+        // 4. Conversation filter: case-insensitive substring match on
+        //    [data-name]; toggles .is-hidden on each row, shows an empty hint.
+        if (filterEl) {
+            var rows = document.querySelectorAll(".conv-list__row");
+            var emptyHint = document.querySelector(".chat-search__empty");
+            filterEl.addEventListener("input", function () {
+                var q = filterEl.value.trim().toLowerCase();
+                var anyVisible = false;
+                rows.forEach(function (row) {
+                    var name = (row.getAttribute("data-name") || "").toLowerCase();
+                    var hit = q === "" || name.indexOf(q) !== -1;
+                    row.classList.toggle("is-hidden", !hit);
+                    if (hit) anyVisible = true;
+                });
+                if (emptyHint) emptyHint.hidden = anyVisible || rows.length === 0;
+            });
+        }
+    }
+
+    function appendOptimisticBubble(scrollEl, text) {
+        if (!scrollEl) return;
+        // Build inside the latest .chat-day so the bubble lives under the right
+        // date pill. If no group exists yet (first message of an empty thread),
+        // create a "Today" group on the fly.
+        var lastGroup = scrollEl.querySelector(".chat-day:last-of-type");
+        if (!lastGroup) {
+            // Remove any "No messages yet" empty hint
+            var hint = scrollEl.querySelector(".empty-hint");
+            if (hint) hint.remove();
+            lastGroup = document.createElement("div");
+            lastGroup.className = "chat-day";
+            var sep = document.createElement("div");
+            sep.className = "chat-day__sep";
+            var sepInner = document.createElement("span");
+            sepInner.textContent = "Today";
+            sep.appendChild(sepInner);
+            lastGroup.appendChild(sep);
+            scrollEl.appendChild(lastGroup);
+        }
+        var bubble = document.createElement("div");
+        bubble.className = "bubble bubble--mine bubble--pending";
+        var p = document.createElement("p");
+        p.className = "bubble__text";
+        p.textContent = text;
+        bubble.appendChild(p);
+        var time = document.createElement("time");
+        time.className = "bubble__time";
+        var now = new Date();
+        var hh = String(now.getHours()).padStart(2, "0");
+        var mm = String(now.getMinutes()).padStart(2, "0");
+        time.textContent = hh + ":" + mm;
+        bubble.appendChild(time);
+        lastGroup.appendChild(bubble);
+        scrollEl.scrollTop = scrollEl.scrollHeight;
+    }
+
     /* ---- Scroll reveals: landing-page IntersectionObserver. Adds .is-revealed
            when an element with [data-reveal] crosses ~15% of the viewport. ---- */
     function initScrollReveals() {
@@ -311,5 +437,6 @@
         initSidebarDrawer();
         initCountUp();
         initScrollReveals();
+        initChatPage();
     });
 })();

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -35,42 +35,73 @@
 
         <div class="chat-layout card card--flush">
             <aside class="chat-sidebar">
-                <h2 class="chat-sidebar__title">Conversations</h2>
+                <div class="chat-sidebar__head">
+                    <h2 class="chat-sidebar__title">Conversations</h2>
+                    <input type="search" class="chat-search js-conv-filter"
+                           placeholder="Search clients…" aria-label="Search conversations"/>
+                </div>
                 <ul class="conv-list" th:if="${partners != null and !partners.isEmpty()}">
-                    <li th:each="p : ${partners}">
+                    <li th:each="p : ${partners}" class="conv-list__row" th:attr="data-name=${p.partnerName}">
                         <a th:href="|/messages/${p.partnerId}|" class="conv-list__item"
                            th:classappend="${activePartnerId != null and activePartnerId == p.partnerId} ? ' conv-list__item--active' : ''">
-                            <span class="conv-list__avatar" th:text="${p.partnerInitials}">AB</span>
+                            <span class="conv-list__avatar">
+                                <span th:text="${p.partnerInitials}">AB</span>
+                                <span class="conv-list__online" aria-hidden="true"></span>
+                            </span>
                             <div class="conv-list__body">
                                 <span class="conv-list__name" th:text="${p.partnerName}">Name</span>
                                 <span class="conv-list__preview" th:text="${p.lastMessage}">…</span>
                             </div>
-                            <span th:if="${p.unreadCount != null and p.unreadCount > 0}" class="badge badge--sm" th:text="${p.unreadCount}">1</span>
+                            <span th:if="${p.unreadCount != null and p.unreadCount > 0}" class="conv-list__unread" th:text="${p.unreadCount}">1</span>
                         </a>
                     </li>
                 </ul>
                 <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet.</p>
+                <p class="empty-hint empty-hint--pad chat-search__empty" hidden>No matches for that search.</p>
             </aside>
             <section class="chat-main">
                 <header class="chat-main__head" th:if="${activePartnerId != null}">
-                    <span class="conv-list__avatar" th:text="${activePartnerInitials}">AB</span>
-                    <h2 class="chat-main__title" th:text="${activePartnerName}">Partner</h2>
+                    <span class="conv-list__avatar conv-list__avatar--lg">
+                        <span th:text="${activePartnerInitials}">AB</span>
+                        <span class="conv-list__online" aria-hidden="true"></span>
+                    </span>
+                    <div class="chat-main__head-body">
+                        <h2 class="chat-main__title" th:text="${activePartnerName}">Partner</h2>
+                        <p class="chat-main__subtitle">
+                            <span class="chat-main__role" th:if="${activePartnerRole}" th:text="${activePartnerRole}">role</span>
+                            <span class="chat-main__sep" th:if="${activePartnerRole}">·</span>
+                            <span class="chat-main__status">Active recently</span>
+                        </p>
+                    </div>
                 </header>
                 <div class="chat-main__head chat-main__head--empty" th:if="${activePartnerId == null}">
                     <p class="empty-hint">Select a client conversation.</p>
                 </div>
-                <div class="chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
-                    <div th:each="m : ${conversation}"
-                         th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
-                        <p class="bubble__text" th:text="${m.message}">Text</p>
-                        <time class="bubble__time" th:text="${m.sentAt}">Time</time>
+                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
+                    <p class="empty-hint" th:if="${conversationGroups == null or conversationGroups.isEmpty()}">
+                        No messages yet.
+                    </p>
+                    <div th:each="day : ${conversationGroups}" class="chat-day">
+                        <div class="chat-day__sep"><span th:text="${day.label}">Today</span></div>
+                        <div th:each="m : ${day.messages}"
+                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
+                            <p class="bubble__text" th:text="${m.message}">Text</p>
+                            <time class="bubble__time" th:text="${m.sentTime}">14:32</time>
+                        </div>
                     </div>
-                    <p class="empty-hint" th:if="${conversation == null or conversation.isEmpty()}">No messages yet.</p>
                 </div>
-                <form th:if="${activePartnerId != null}" class="chat-compose" th:action="|/messages/${activePartnerId}|" method="post">
+                <form th:if="${activePartnerId != null}" class="chat-compose js-chat-compose"
+                      th:action="|/messages/${activePartnerId}|" method="post"
+                      th:attr="data-partner-id=${activePartnerId}">
                     <label class="sr-only" for="pro-msg-input">Message</label>
-                    <textarea id="pro-msg-input" name="message" rows="2" required placeholder="Write a message…"></textarea>
-                    <button type="submit" class="btn btn--primary">Send</button>
+                    <textarea id="pro-msg-input" name="message" rows="1" required placeholder="Message…"
+                              class="chat-compose__input js-chat-input"></textarea>
+                    <button type="submit" class="chat-compose__send js-chat-send" aria-label="Send message" disabled>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M5 12 L 19 5 L 14 19 L 12 13 Z"/>
+                        </svg>
+                    </button>
                 </form>
             </section>
         </div>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -39,42 +39,73 @@
 
         <div class="chat-layout card card--flush">
             <aside class="chat-sidebar">
-                <h2 class="chat-sidebar__title">Conversations</h2>
+                <div class="chat-sidebar__head">
+                    <h2 class="chat-sidebar__title">Conversations</h2>
+                    <input type="search" class="chat-search js-conv-filter"
+                           placeholder="Search…" aria-label="Search conversations"/>
+                </div>
                 <ul class="conv-list" th:if="${partners != null and !partners.isEmpty()}">
-                    <li th:each="p : ${partners}">
+                    <li th:each="p : ${partners}" class="conv-list__row" th:attr="data-name=${p.partnerName}">
                         <a th:href="|/messages/${p.partnerId}|" class="conv-list__item"
                            th:classappend="${activePartnerId != null and activePartnerId == p.partnerId} ? ' conv-list__item--active' : ''">
-                            <span class="conv-list__avatar" th:text="${p.partnerInitials}">AB</span>
+                            <span class="conv-list__avatar">
+                                <span th:text="${p.partnerInitials}">AB</span>
+                                <span class="conv-list__online" aria-hidden="true"></span>
+                            </span>
                             <div class="conv-list__body">
                                 <span class="conv-list__name" th:text="${p.partnerName}">Name</span>
                                 <span class="conv-list__preview" th:text="${p.lastMessage}">…</span>
                             </div>
-                            <span th:if="${p.unreadCount != null and p.unreadCount > 0}" class="badge badge--sm" th:text="${p.unreadCount}">1</span>
+                            <span th:if="${p.unreadCount != null and p.unreadCount > 0}" class="conv-list__unread" th:text="${p.unreadCount}">1</span>
                         </a>
                     </li>
                 </ul>
                 <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet.</p>
+                <p class="empty-hint empty-hint--pad chat-search__empty" hidden>No matches for that search.</p>
             </aside>
             <section class="chat-main">
                 <header class="chat-main__head" th:if="${activePartnerId != null}">
-                    <span class="conv-list__avatar" th:text="${activePartnerInitials}">AB</span>
-                    <h2 class="chat-main__title" th:text="${activePartnerName}">Partner</h2>
+                    <span class="conv-list__avatar conv-list__avatar--lg">
+                        <span th:text="${activePartnerInitials}">AB</span>
+                        <span class="conv-list__online" aria-hidden="true"></span>
+                    </span>
+                    <div class="chat-main__head-body">
+                        <h2 class="chat-main__title" th:text="${activePartnerName}">Partner</h2>
+                        <p class="chat-main__subtitle">
+                            <span class="chat-main__role" th:if="${activePartnerRole}" th:text="${activePartnerRole}">role</span>
+                            <span class="chat-main__sep" th:if="${activePartnerRole}">·</span>
+                            <span class="chat-main__status">Active recently</span>
+                        </p>
+                    </div>
                 </header>
                 <div class="chat-main__head chat-main__head--empty" th:if="${activePartnerId == null}">
                     <p class="empty-hint">Select a conversation to read messages.</p>
                 </div>
-                <div class="chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
-                    <div th:each="m : ${conversation}"
-                         th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
-                        <p class="bubble__text" th:text="${m.message}">Text</p>
-                        <time class="bubble__time" th:text="${m.sentAt}">Time</time>
+                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
+                    <p class="empty-hint" th:if="${conversationGroups == null or conversationGroups.isEmpty()}">
+                        No messages yet — say hello!
+                    </p>
+                    <div th:each="day : ${conversationGroups}" class="chat-day">
+                        <div class="chat-day__sep"><span th:text="${day.label}">Today</span></div>
+                        <div th:each="m : ${day.messages}"
+                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
+                            <p class="bubble__text" th:text="${m.message}">Text</p>
+                            <time class="bubble__time" th:text="${m.sentTime}">14:32</time>
+                        </div>
                     </div>
-                    <p class="empty-hint" th:if="${conversation == null or conversation.isEmpty()}">No messages yet — say hello!</p>
                 </div>
-                <form th:if="${activePartnerId != null}" class="chat-compose" th:action="|/messages/${activePartnerId}|" method="post">
+                <form th:if="${activePartnerId != null}" class="chat-compose js-chat-compose"
+                      th:action="|/messages/${activePartnerId}|" method="post"
+                      th:attr="data-partner-id=${activePartnerId}">
                     <label class="sr-only" for="msg-input">Message</label>
-                    <textarea id="msg-input" name="message" rows="2" required placeholder="Write a message…"></textarea>
-                    <button type="submit" class="btn btn--primary">Send</button>
+                    <textarea id="msg-input" name="message" rows="1" required placeholder="Message…"
+                              class="chat-compose__input js-chat-input"></textarea>
+                    <button type="submit" class="chat-compose__send js-chat-send" aria-label="Send message" disabled>
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M5 12 L 19 5 L 14 19 L 12 13 Z"/>
+                        </svg>
+                    </button>
                 </form>
             </section>
         </div>


### PR DESCRIPTION
Closes #99.

## Summary
Refresh `/messages` (subscriber + professional) with Telegram's visual hallmarks and the silky interactions to match — sticky chat header, bubble tails, sticky date separators, dotted wallpaper, pill composer with circular send. AJAX-submit so sending no longer reloads the page.

## Visual highlights
- Sticky chat header with avatar + name + role + status line
- Conversation rows redesigned as rounded items inside the rail with online dots and primary-tinted unread pills
- Bubbles grow CSS pseudo-element tails pointing to the sender corner
- Sticky date pills (`Today / Yesterday / Monday / MMM d, yyyy`) between message clusters — the controller groups by date
- Pill input + circular paper-plane send button replaces the rectangle textarea + button
- Active conversation in the list flips to sage-primary fill with inverted avatar — much more legible than the prior subtle tint

## Smooth interactions (all `prefers-reduced-motion` aware via the existing global guard)
- Auto-scroll to bottom on load (instant, no top-flash)
- Composer textarea auto-resizes from 1 line to a 140px cap
- Enter sends, Shift+Enter newlines, send button disabled when empty
- Optimistic AJAX submit — `fetch(POST, FormData)` appends the bubble locally with `.bubble--pending` while the server acknowledges; on failure it flips to `.bubble--failed`. Page no longer reloads.
- Composer auto-focuses so a returning user can just type
- Conversation list filter (live substring match on `[data-name]`)

## Backend changes (low-risk)
- `MessageService.getConversation` now also returns `sentDate` (`LocalDate`) and `sentTime` (`HH:mm`). Existing callers still get `sentAt` and `isMine`.
- `MessageRoutes` adds `conversationGroups` (grouped by date with labels) and `activePartnerRole` to the model. Existing template fields preserved for backward compat.
- `POST /messages/:id` is unchanged — still 302-redirects. AJAX `fetch` ignores the response body.

## Test plan
- [ ] Open `/messages` as a subscriber — sticky header shows partner name + role + "Active recently". Avatar has the small mint online dot.
- [ ] Conversation list rows: hover slides them right by 2px; active row is a sage-filled card.
- [ ] Search box filters conversations by name; clearing it restores all rows; non-matching query shows the empty hint.
- [ ] Message log loads scrolled to the bottom (no top-flash). Date pills appear between days and stick at the top while scrolling through that day.
- [ ] Bubbles have small triangles pointing to their sender corner; mine = sage with cream text, theirs = warm cream with deep text.
- [ ] Type a message and hit Enter — bubble appears immediately with "sending…" annotation; after the POST completes, "sending…" disappears. No page reload.
- [ ] Shift+Enter inserts a newline. Send button is disabled while the input is empty.
- [ ] Open as a professional — same flow with "Search clients…" placeholder.
- [ ] Toggle dark mode — every element reads correctly.