### PR TITLE
fix: fluid main width — pages no longer cap at 1200px on wide displays (v0.6.27)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.27] - 2026-05-03 — Fluid main width — pages no longer cap at 1200px on wide displays (closes #101)
+
+### Changed
+- `.main` `max-width: 1200px` → `1680px`. Every authenticated page used to stop ~30-40% short of the viewport on a 1440 / 1920 / 2560+ display. Now scales out 40% wider while still capping for readability on 4K monitors.
+- `.main` padding moved from a static `32px 36px` to `clamp(28px, 3vh, 40px) clamp(28px, 4vw, 72px)` so the breathing room scales with the viewport — tighter on tablets, more generous on widescreens, capped both ways.
+- `.main--chat` matches the same `1680px` cap (was `1280px`). The chat self-constrains via its conversation-rail width + bubble `max-width: 72%`, so it can ride the wider container without bubbles spanning awkwardly far.
+
+### Not changed
+- All sub-layouts inside `.main` already use `width: 100%` cards, `auto-fill` grids, or `fr` units — they grow naturally with the wider container without any additional changes. Nothing visually breaks; pages just use the screen they're given.
+- Mobile / tablet overrides (`@media (max-width: 1024px)`, `840px`, `600px`) untouched. They still pin to tighter padding for those viewports.
+
+---
+
 ## [v0.6.26] - 2026-05-03 — Messages: Telegram-style polish + smooth interactions (closes #99)
 
 ### Added (visual)

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -781,12 +781,18 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 
 .main {
     flex: 1;
-    padding: 32px 36px;
-    max-width: 1200px;
+    /* Fluid padding: tightens on small screens, breathes on wide ones,
+       capped so it doesn't grow infinitely on 4K displays. */
+    padding: clamp(28px, 3vh, 40px) clamp(28px, 4vw, 72px);
+    /* Was 1200px — content stopped 30%+ short of any widescreen display.
+       Bump to 1680px so 1440 / 1920 monitors actually use their viewport. */
+    max-width: 1680px;
     width: 100%;
     animation: fade-up var(--dur-slow) var(--ease-out) both;
 }
-.main--chat { max-width: 1280px; }
+/* Chat self-constrains via the conversation rail + bubble max-widths,
+   so it can ride the same 1680px cap as the rest of the app. */
+.main--chat { max-width: 1680px; }
 
 .page-header { margin-bottom: 28px; }
 .page-header--row {


### PR DESCRIPTION
Closes #101.

## Summary
- `.main` `max-width` bumped from `1200px` → `1680px` so pages actually use a 1440 / 1920 / 2560+ display.
- `.main` padding switches from static `32px 36px` to `clamp(28px, 3vh, 40px) clamp(28px, 4vw, 72px)` — fluid breathing room that scales with viewport, capped both ways.
- `.main--chat` now matches at `1680px` (was `1280px`). The chat self-constrains via the conversation rail + `bubble { max-width: 72% }`, so widening the container doesn't make bubbles span ridiculously far.

## What does NOT change
- Mobile / tablet overrides at `≤1024px`, `≤840px`, `≤600px` are untouched — those viewports keep tighter padding.
- All cards, grids, and `fr`-based layouts inside `.main` already use `width: 100%` / `auto-fill` / fractional columns. They grow naturally with the wider container, no further CSS needed.

## Test plan
- [ ] On a 1440px+ display, every page (`/`, `/dashboard`, `/diary`, `/recipes`, `/goals`, `/messages`, `/profile`) now extends ~40% further right than before — no big empty band on the right.
- [ ] Resize the browser window — content reflows smoothly thanks to the clamp padding (no padding "snap" except at the explicit `≤1024px` breakpoint).
- [ ] Mobile breakpoints unaffected: `≤840px` still hides the sidebar drawer + tightens to `16px` horizontal padding.
- [ ] Chat layout (Messages page) at the wider 1680px cap: conversation rail stays around 320px, message column fills the rest, bubbles still cap at 72% of the message column.