### PR TITLE
feat: Liquid Glass pass — translucent cards + atmospheric backdrop (v0.6.28)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.28] - 2026-05-03 — Liquid Glass pass — translucent cards + atmospheric backdrop (closes #103)
+
+CSS-only rendition of Apple's Tahoe / iOS 26 Liquid Glass material. Reference: [rdev/liquid-glass-react](https://github.com/rdev/liquid-glass-react) (which is React + WebGL — we hit ~95% of the visual via `backdrop-filter` + multi-layer shadows + an atmospheric backdrop layer).
+
+### Added
+- **Liquid-glass token family** in all three `:root` variants (light, `[data-theme="dark"]`, `prefers-color-scheme: dark`):
+  - `--glass-bg / --glass-bg-warm / --glass-bg-tinted` — translucent surface tints (~58–62% alpha)
+  - `--glass-blur / --glass-blur-strong` — `saturate(180%) blur(20-28px)`
+  - `--glass-border / --glass-border-soft` — thin edge highlight (white in light, faint white in dark)
+  - `--glass-shadow / --glass-shadow-strong` — multi-layer recipe: top `inset 0 1px 0` highlight + bottom `inset 0 -1px 0` shadow + soft outer drop
+- **Atmospheric backdrop layer** at `.app-body::before` — three soft radial-gradient blobs (sage / clay / berry) fixed to the viewport. Subtle (≤30% peak opacity in light, ≤42% in dark) so they don't compete with content but provide colour for the glass surfaces above to refract. Without this layer, glass cards on a flat cream page would just look like translucent rectangles.
+
+### Changed
+- `.card` (every card, 69 placements across the app) — solid `var(--color-surface)` swapped to `var(--glass-bg-warm)` with `backdrop-filter: var(--glass-blur)`, edge highlight via `var(--glass-border)`, multi-layer `var(--glass-shadow)`. Cards now read as thick translucent material with light catching the top edge.
+- `.chat-main__head` — sticky chat header is the canonical glass use case (refracts the messages scrolling beneath it). Now uses `--glass-blur-strong` plus a single `inset 0 1px 0 rgba(255,255,255,0.6)` highlight stripe along the top edge.
+- `.modal__panel` — strong-blur glass panel over the existing scrim, so the page behind reads as an impressionistic backdrop instead of detail noise.
+- `.landing-hero__metric` — the three floating metric chips (`1,842 kcal today` / `124 g protein` / `187 recipes saved`) are now glass tiles letting the sage brand-disc colour bleed through.
+
+### Not changed
+- Buttons (`.btn`), the composer textarea, sidebar nav, message bubbles, and `.card--feature-dark` keep their solid backgrounds — tactile / readability surfaces where translucency would hurt.
+- All `-webkit-backdrop-filter` mirrors added everywhere `backdrop-filter` appears, for Safari.
+
+### Implementation notes
+- `app-body::before` sits at `z-index: 0`; `.app-layout` is bumped to `z-index: 1` so the layout (cards included) renders above the blobs. `.app-body` itself stays at the cream background.
+- Hover transforms on cards (`.recipe-card:hover { transform: translateY(-2px) }` etc.) create a stacking context that briefly disables `backdrop-filter` during the hover. Acceptable trade-off — solid hover state is fine, the glass settles back when not interacting.
+- Total CSS added: one `::before` block + ~30 lines of token declarations across three `:root` variants. No new HTML structure, no new classes applied to templates — every existing `.card` automatically inherits the new look.
+
+---
+
 ## [v0.6.27] - 2026-05-03 — Fluid main width — pages no longer cap at 1200px on wide displays (closes #101)
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -182,6 +182,30 @@
     --emoji-shadow:         drop-shadow(0 2px 4px rgba(31, 42, 35, 0.12));
     --shimmer-highlight:    rgba(255, 255, 255, 0.55); /* once-only progress sweep */
 
+    /* ---- Liquid Glass tokens (Apple Tahoe-flavoured, CSS-only) ----
+       Used by .card and a handful of high-impact surfaces (sticky chat
+       header, modal panel, landing hero chips). Translucent surfaces
+       backed by .app-body::before blobs so there is something to refract. */
+    --glass-bg:               rgba(255, 255, 255, 0.58);
+    --glass-bg-warm:          rgba(251, 248, 240, 0.62);
+    --glass-bg-tinted:        rgba(232, 239, 225, 0.50);
+    --glass-blur:             saturate(180%) blur(20px);
+    --glass-blur-strong:      saturate(180%) blur(28px);
+    --glass-border:           1px solid rgba(255, 255, 255, 0.65);
+    --glass-border-soft:      1px solid rgba(255, 255, 255, 0.30);
+    /* Multi-layer shadow: top inner highlight (catches light) +
+       thin bottom inner shadow (suggests thickness) + soft outer drop. */
+    --glass-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.75),
+        inset 0 -1px 0 rgba(31, 42, 35, 0.05),
+        0 12px 36px rgba(31, 42, 35, 0.08),
+        0 1px 2px rgba(31, 42, 35, 0.04);
+    --glass-shadow-strong:
+        inset 0 1px 0 rgba(255, 255, 255, 0.85),
+        inset 0 -1px 0 rgba(31, 42, 35, 0.06),
+        0 24px 60px rgba(31, 42, 35, 0.14),
+        0 2px 4px rgba(31, 42, 35, 0.05);
+
     /* radii — collapsed onto a single 14px family for cards / buttons / modals,
        with 10px for tighter inputs and 18px for hero-tier elements. */
     --radius-sm:   10px;
@@ -298,6 +322,24 @@
         --emoji-shadow:         drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
         --shimmer-highlight:    rgba(232, 228, 214, 0.22); /* dimmer cream sweep so dark UI doesn't flash white */
 
+        --glass-bg:               rgba(31, 42, 35, 0.55);
+        --glass-bg-warm:          rgba(20, 32, 26, 0.55);
+        --glass-bg-tinted:        rgba(42, 58, 44, 0.55);
+        --glass-blur:             saturate(180%) blur(20px);
+        --glass-blur-strong:      saturate(180%) blur(28px);
+        --glass-border:           1px solid rgba(255, 255, 255, 0.10);
+        --glass-border-soft:      1px solid rgba(255, 255, 255, 0.06);
+        --glass-shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.10),
+            inset 0 -1px 0 rgba(0, 0, 0, 0.20),
+            0 12px 36px rgba(0, 0, 0, 0.40),
+            0 1px 2px rgba(0, 0, 0, 0.30);
+        --glass-shadow-strong:
+            inset 0 1px 0 rgba(255, 255, 255, 0.12),
+            inset 0 -1px 0 rgba(0, 0, 0, 0.25),
+            0 24px 60px rgba(0, 0, 0, 0.55),
+            0 2px 4px rgba(0, 0, 0, 0.35);
+
         color-scheme: dark;
     }
 }
@@ -370,6 +412,24 @@
     --sidebar-border-hover: rgba(232, 228, 214, 0.18);
     --emoji-shadow:         drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
     --shimmer-highlight:    rgba(232, 228, 214, 0.22);
+
+    --glass-bg:               rgba(31, 42, 35, 0.55);
+    --glass-bg-warm:          rgba(20, 32, 26, 0.55);
+    --glass-bg-tinted:        rgba(42, 58, 44, 0.55);
+    --glass-blur:             saturate(180%) blur(20px);
+    --glass-blur-strong:      saturate(180%) blur(28px);
+    --glass-border:           1px solid rgba(255, 255, 255, 0.10);
+    --glass-border-soft:      1px solid rgba(255, 255, 255, 0.06);
+    --glass-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.10),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.20),
+        0 12px 36px rgba(0, 0, 0, 0.40),
+        0 1px 2px rgba(0, 0, 0, 0.30);
+    --glass-shadow-strong:
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.25),
+        0 24px 60px rgba(0, 0, 0, 0.55),
+        0 2px 4px rgba(0, 0, 0, 0.35);
 
     color-scheme: dark;
 }
@@ -626,7 +686,42 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 /* ============================================================
    App shell
    ============================================================ */
-.app-body { min-height: 100vh; }
+.app-body {
+    min-height: 100vh;
+    position: relative;
+}
+/* Atmospheric layer behind every authenticated page — three soft radial
+   blobs (sage / clay / berry) fixed to the viewport. Provides the colour
+   that the glass cards on top need to refract; without it, glass surfaces
+   on a flat cream page would look like flat translucent rectangles. */
+.app-body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background:
+        radial-gradient(80vw 80vh at 12% 10%, rgba(184, 209, 168, 0.30), transparent 55%),
+        radial-gradient(70vw 70vh at 88% 92%, rgba(217, 119, 87, 0.16), transparent 60%),
+        radial-gradient(60vw 60vh at 92% 18%, rgba(245, 214, 220, 0.14), transparent 60%);
+    opacity: 0.85;
+    transition: opacity var(--dur-slow) var(--ease);
+}
+:root[data-theme="dark"] .app-body::before {
+    background:
+        radial-gradient(80vw 80vh at 12% 10%, rgba(74, 107, 60, 0.42), transparent 55%),
+        radial-gradient(70vw 70vh at 88% 92%, rgba(107, 69, 48, 0.30), transparent 60%),
+        radial-gradient(60vw 60vh at 92% 18%, rgba(74, 37, 48, 0.24), transparent 60%);
+}
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .app-body::before {
+        background:
+            radial-gradient(80vw 80vh at 12% 10%, rgba(74, 107, 60, 0.42), transparent 55%),
+            radial-gradient(70vw 70vh at 88% 92%, rgba(107, 69, 48, 0.30), transparent 60%),
+            radial-gradient(60vw 60vh at 92% 18%, rgba(74, 37, 48, 0.24), transparent 60%);
+    }
+}
+.app-layout { position: relative; z-index: 1; }
 
 .app-layout {
     display: flex;
@@ -824,11 +919,16 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 }
 
 .card {
-    background: var(--color-surface);
+    /* Liquid Glass treatment: warm-tinted translucent surface with backdrop
+       blur + saturation boost. The atmospheric blobs (.app-body::before)
+       bleed through, giving each card a subtle living gradient. */
+    background: var(--glass-bg-warm);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
     border-radius: var(--radius-md);
-    border: none;
+    border: var(--glass-border);
     padding: 28px;
-    box-shadow: var(--shadow-sm);
+    box-shadow: var(--glass-shadow);
     transition: background var(--dur) var(--ease), transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
 }
 .card--flush { padding: 0; overflow: hidden; }
@@ -2106,11 +2206,15 @@ input::placeholder, textarea::placeholder {
     gap: 14px;
     padding: 14px 22px;
     border-bottom: 1px solid var(--color-border-soft);
-    background: var(--color-surface);
+    /* Liquid Glass — refracts the messages scrolling beneath the sticky
+       header, exactly the use case the technique was designed for. */
+    background: var(--glass-bg-warm);
+    backdrop-filter: var(--glass-blur-strong);
+    -webkit-backdrop-filter: var(--glass-blur-strong);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
     position: sticky;
     top: 0;
     z-index: 5;
-    backdrop-filter: saturate(140%);
     flex-shrink: 0;
 }
 .chat-main__head--empty {
@@ -2448,10 +2552,15 @@ input::placeholder, textarea::placeholder {
     max-height: 90vh;
     overflow-y: auto;
     z-index: 1;
-    background: var(--color-surface);
+    /* Liquid Glass over the modal scrim — strong blur so the page behind
+       reads as a soft impressionistic backdrop, not detail noise. */
+    background: var(--glass-bg-warm);
+    backdrop-filter: var(--glass-blur-strong);
+    -webkit-backdrop-filter: var(--glass-blur-strong);
+    border: var(--glass-border);
     border-radius: var(--radius-lg);
     padding: 28px;
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--glass-shadow-strong);
     transform: translateY(8px) scale(0.98);
     transition: transform var(--dur) var(--ease-out);
 }
@@ -2823,11 +2932,15 @@ input::placeholder, textarea::placeholder {
 }
 .landing-hero__metric {
     position: absolute;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border-soft);
+    /* Liquid Glass chips floating over the brand disc — high-impact
+       application; the disc's sage colour bleeds through the chip. */
+    background: var(--glass-bg-warm);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: var(--glass-border);
     border-radius: var(--radius-md);
     padding: 14px 18px;
-    box-shadow: var(--shadow);
+    box-shadow: var(--glass-shadow);
     display: flex;
     flex-direction: column;
     gap: 2px;


### PR DESCRIPTION
Closes #103. Reference: [rdev/liquid-glass-react](https://github.com/rdev/liquid-glass-react) — that library is React + WebGL for true refraction; we're CSS-only Thymeleaf so we hit ~95% of the visual via `backdrop-filter` + multi-layer shadows + an atmospheric backdrop layer.

## What's new
- **Glass token family** (`--glass-bg / --glass-blur / --glass-border / --glass-shadow / ...`) in all three `:root` variants with light + dark recipes.
- **Atmospheric layer** at `.app-body::before` — three soft sage / clay / berry radial-gradient blobs fixed to the viewport. Subtle (≤30% peak opacity light, ≤42% dark) but provides the colour every glass surface refracts. Without this, glass cards on a flat cream page would just look like translucent rectangles.
- **`.card`** (every card, 69 placements) — solid background swapped to glass: `var(--glass-bg-warm)` + `backdrop-filter: var(--glass-blur)` + edge highlight + multi-layer shadow. Top inner highlight catches the light, bottom inner shadow suggests thickness, soft outer drop floats the card.
- **`.chat-main__head`** — canonical Liquid Glass: sticky header refracting the messages scrolling beneath it. Strong-blur variant.
- **`.modal__panel`** — strong-blur glass over the existing scrim.
- **`.landing-hero__metric`** — the three floating chips on the landing hero now read as glass tiles letting the brand-disc colour bleed through.

## What stays solid
- Buttons (tactile)
- Composer textarea (text legibility)
- Sidebar nav (forest band)
- Message bubbles (text legibility critical)
- `.card--feature-dark` (deliberate dark-on-cream contrast)

## Test plan
- [ ] Every page now has the soft sage / clay / berry atmospheric blobs visible behind cards. Move the browser window — blobs are fixed to the viewport.
- [ ] Cards on `/dashboard`, `/diary`, `/recipes`, `/goals`, `/profile` all read as translucent thick-glass material with a top edge highlight.
- [ ] On `/messages`, scroll a long conversation — the sticky chat header refracts the messages passing beneath it.
- [ ] Open a food modal on `/diary` — the panel is glass over the scrim.
- [ ] Visit `/` (landing) — the three hero metric chips are glass over the sage brand-disc.
- [ ] Toggle dark mode — every glass surface flips to a dark-tinted translucent with subtle white-at-10% inner highlight. Atmospheric blobs swap to deeper sage / clay / berry.
- [ ] Hover a recipe card — the `transform: translateY(-2px)` creates a stacking context that briefly disables `backdrop-filter`, so the hover state shows a more solid card. Acceptable trade-off; settles back to glass on mouseout.