### PR TITLE
fix: dashboard For tonight shows real recipe images, not emoji (v0.6.29)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.29] - 2026-05-03 — Dashboard "For tonight" cards now show real recipe images (closes #105)
+
+### Fixed
+- The 3 seed recipes (`Grilled Chicken Salad` / `Overnight Oats Bowl` / `Grilled Salmon with Veggies`) all have real Unsplash `imageUrl` values seeded by `SeedData.backfillImageUrls()`, but the dashboard's "For tonight" section was rendering the emoji fallback every time because `DashboardRoutes.kt`'s `featured` map projection silently dropped the `imageUrl` field.
+- Added `imageUrl` to the controller's projection (passed through as nullable so the template can fall through to the emoji when a recipe genuinely has no image).
+- Mirrored the `recipes.html` pattern in `subscriber/dashboard.html`: `<img th:if="${f.imageUrl != null}">` first, emoji span as the fallback. Cover gradient class only applied when there's no image (so the image isn't tinted by a sage/clay/berry overlay).
+- New `.dashboard-tonight__img` CSS rule: `object-fit: cover` + `width/height: 100%` + a subtle `scale(1.04)` zoom on card hover, matching the existing `.recipe-card__cover-img` behaviour on the recipes grid.
+
+---
+
 ## [v0.6.28] - 2026-05-03 — Liquid Glass pass — translucent cards + atmospheric backdrop (closes #103)
 
 CSS-only rendition of Apple's Tahoe / iOS 26 Liquid Glass material. Reference: [rdev/liquid-glass-react](https://github.com/rdev/liquid-glass-react) (which is React + WebGL — we hit ~95% of the visual via `backdrop-filter` + multi-layer shadows + an atmospheric backdrop layer).

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DashboardRoutes.kt
@@ -72,10 +72,14 @@ fun Route.dashboardRoutes() {
         }
         val loggedDays = weekly.count { it["isLogged"] == true }
 
-        val featured = RecipeService.getFeatured(3).map { r ->
+        val featured: List<Map<String, Any?>> = RecipeService.getFeatured(3).map { r ->
             mapOf(
                 "id" to (r["id"] ?: 0),
                 "title" to (r["title"] ?: ""),
+                // Pass null through when the recipe has no real image, so the
+                // template's `th:if="${f.imageUrl != null}"` falls through to
+                // the emoji fallback instead of rendering an <img src="">.
+                "imageUrl" to r["imageUrl"],
                 "coverEmoji" to (r["coverEmoji"] ?: "🍽️"),
                 "coverTone" to (r["coverTone"] ?: "sage"),
                 "avgRating" to (r["avgRating"] as BigDecimal).fmt(1),

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -3490,6 +3490,15 @@ input::placeholder, textarea::placeholder {
     background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft));
 }
 .dashboard-tonight__cover--small { aspect-ratio: 16 / 9; }
+.dashboard-tonight__cover { overflow: hidden; }
+.dashboard-tonight__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: transform var(--dur-slow) var(--ease-out);
+}
+.dashboard-tonight__card:hover .dashboard-tonight__img { transform: scale(1.04); }
 .dashboard-tonight__emoji {
     font-size: 56px;
     line-height: 1;

--- a/2850final project/src/main/resources/templates/subscriber/dashboard.html
+++ b/2850final project/src/main/resources/templates/subscriber/dashboard.html
@@ -156,9 +156,11 @@
                          th:if="${featured.size() > 0}" th:with="f=${featured[0]}"
                          style="--i: 0">
                     <a th:href="|/recipes/${f.id}|" class="dashboard-tonight__link">
-                        <div th:classappend="|recipe-card__cover--${f.coverTone}|"
+                        <div th:classappend="${f.imageUrl == null} ? |recipe-card__cover--${f.coverTone}| : ''"
                              class="dashboard-tonight__cover">
-                            <span class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
+                            <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}"
+                                 class="dashboard-tonight__img" loading="lazy" width="800" height="500"/>
+                            <span th:if="${f.imageUrl == null}" class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
                             <span class="dashboard-tonight__rating" th:if="${f.reviewCount > 0}">★ <span th:text="${f.avgRating}">0</span></span>
                         </div>
                         <div class="dashboard-tonight__body">
@@ -175,9 +177,11 @@
                          th:each="f, iter : ${featured}" th:if="${iter.index > 0}"
                          th:style="|--i: ${iter.index}|">
                     <a th:href="|/recipes/${f.id}|" class="dashboard-tonight__link">
-                        <div th:classappend="|recipe-card__cover--${f.coverTone}|"
+                        <div th:classappend="${f.imageUrl == null} ? |recipe-card__cover--${f.coverTone}| : ''"
                              class="dashboard-tonight__cover dashboard-tonight__cover--small">
-                            <span class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
+                            <img th:if="${f.imageUrl != null}" th:src="${f.imageUrl}" th:alt="${f.title}"
+                                 class="dashboard-tonight__img" loading="lazy" width="800" height="500"/>
+                            <span th:if="${f.imageUrl == null}" class="dashboard-tonight__emoji" th:text="${f.coverEmoji}">🍲</span>
                         </div>
                         <div class="dashboard-tonight__body">
                             <h3 class="dashboard-tonight__title" th:text="${f.title}">Recipe</h3>


### PR DESCRIPTION
Closes #105.

## Summary
The dashboard's "For tonight" cards have been rendering the emoji fallback (🐟 / 🥗 / 🥣) for all three featured recipes, even though those exact recipes have real Unsplash `imageUrl` values seeded by `SeedData.backfillImageUrls()`. Cause: `DashboardRoutes.kt`'s `featured` map projection didn't include `imageUrl`, so the template's emoji fallback was the only branch ever rendered.

## Fix
- `DashboardRoutes.kt`: pass `imageUrl` through nullable.
- `subscriber/dashboard.html`: render `<img>` when present, emoji span otherwise. Mirrors the existing `recipes.html` pattern.
- `styles.css`: new `.dashboard-tonight__img` with `object-fit: cover` + a `scale(1.04)` hover zoom, matching the recipes grid.

## Test plan
- [ ] Visit `/dashboard` — the 3 cards in "For tonight" now show the real food photos (chicken salad, overnight oats, grilled salmon) instead of cartoon emoji.
- [ ] Hover a card — image gently zooms 4%.
- [ ] If a recipe with no `imageUrl` is ever featured, the emoji fallback still renders correctly with the sage/clay/berry cover gradient.