### PR TITLE
feat: messages directory — anyone can DM any opposite-role user (v0.6.30)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.30] - 2026-05-03 — Messages: anyone can DM anyone — full directory of opposite-role users (closes #107)
+
+### Added
+- **Directory section** in both subscriber and professional message sidebars listing every user of the opposite role you haven't yet exchanged messages with. Subscribers see "All professionals", professionals see "All clients". Conversations you've already started stay at the top in their own section; the directory sits below the divider.
+- New `MessageService.getEligibleNewPartners(userId, currentUserRole)` returns users with the opposite `role`, excluding the current user and excluding the IDs already in the conversation history.
+
+### Changed
+- `MessageRoutes` (both `GET /messages` and `GET /messages/{partnerId}`) now pass `directory` in addition to the existing `partners`.
+- Subscriber + professional message templates updated with the new section. Empty-state copy refreshed: `No conversations yet — start one below.` (subscriber) / `No conversations yet — pick a client below to start one.` (professional).
+- Directory rows reuse the existing `.conv-list__row` markup so the search filter and `data-name` attribute keep working across both sections without any JS change.
+- Directory items get a subtle `+` glyph in a dashed circle (replaces the unread badge slot) so they read as "start a chat" affordances.
+
+### Implementation notes
+- `GET /messages/{partnerId}` already worked for never-messaged partners (it fetches the partner via `UserService.getById` and `MessageService.getConversation` returns an empty list cleanly), so no route changes were needed beyond passing the directory list.
+- Initials computed the same way as for conversation partners (first letter of each space-separated word) so avatars render consistently between the two sidebar sections.
+- The directory section's `.conv-list__divider` header sits below the conversations list with `margin: 18px 16px 6px` so the two sections feel related but distinct.
+
+### Out of scope
+- Subscriber-to-subscriber DMs and pro-to-pro DMs (the requirement was "professionals talk to clients, clients talk to professionals", not full social networking).
+- Authorization gating beyond the existing pro-only `hasActiveRelationship` check on the professional dashboard endpoints — basic messaging stays open to any logged-in user-pair.
+
+---
+
 ## [v0.6.29] - 2026-05-03 — Dashboard "For tonight" cards now show real recipe images (closes #105)
 
 ### Fixed

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
@@ -40,13 +40,14 @@ fun Route.messageRoutes() {
     get("/messages") {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         val partners = MessageService.getConversationPartners(session.userId)
+        val directory = MessageService.getEligibleNewPartners(session.userId, session.role)
         val unread = MessageService.getUnreadCount(session.userId)
         val firstPartner = partners.firstOrNull(); val firstPartnerId = firstPartner?.get("partnerId") as? Int
         val conversation = if (firstPartnerId != null) MessageService.getConversation(session.userId, firstPartnerId) else emptyList()
         val groups = groupByDate(conversation, LocalDate.now())
         val template = if (session.role == "professional") "professional/messages" else "subscriber/messages"
         call.respond(ThymeleafContent(template, model(
-            "session" to session, "partners" to partners,
+            "session" to session, "partners" to partners, "directory" to directory,
             "conversation" to conversation, "conversationGroups" to groups,
             "activePartnerId" to firstPartnerId, "activePartnerName" to (firstPartner?.get("partnerName") ?: ""),
             "activePartnerInitials" to (firstPartner?.get("partnerInitials") ?: ""),
@@ -58,6 +59,7 @@ fun Route.messageRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         val partnerId = call.parameters["partnerId"]?.toIntOrNull() ?: return@get call.respondRedirect("/messages")
         val partners = MessageService.getConversationPartners(session.userId)
+        val directory = MessageService.getEligibleNewPartners(session.userId, session.role)
         val conversation = MessageService.getConversation(session.userId, partnerId)
         val groups = groupByDate(conversation, LocalDate.now())
         val partner = UserService.getById(partnerId)
@@ -67,7 +69,7 @@ fun Route.messageRoutes() {
         val pRole = partner?.get(Users.role) ?: ""
         val template = if (session.role == "professional") "professional/messages" else "subscriber/messages"
         call.respond(ThymeleafContent(template, model(
-            "session" to session, "partners" to partners,
+            "session" to session, "partners" to partners, "directory" to directory,
             "conversation" to conversation, "conversationGroups" to groups,
             "activePartnerId" to partnerId, "activePartnerName" to pName,
             "activePartnerInitials" to pInitials, "activePartnerRole" to pRole,

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
@@ -88,4 +88,34 @@ object MessageService {
     fun getUnreadCount(userId: Int): Long = transaction {
         AdviceMessages.selectAll().where { (AdviceMessages.receiverId eq userId) and (AdviceMessages.isRead eq false) }.count()
     }
+
+    /**
+     * "Directory" — every user of the opposite role that [userId] has *not*
+     * yet exchanged messages with. Powers the new-conversation list at the
+     * bottom of `/messages`. Subscribers see professionals, professionals see
+     * subscribers; never returns the current user themselves.
+     */
+    fun getEligibleNewPartners(userId: Int, currentUserRole: String): List<Map<String, Any>> = transaction {
+        val targetRole = if (currentUserRole == "professional") "subscriber" else "professional"
+        val existing: Set<Int> = AdviceMessages.selectAll().where {
+            (AdviceMessages.senderId eq userId) or (AdviceMessages.receiverId eq userId)
+        }.map { row ->
+            if (row[AdviceMessages.senderId] == userId) row[AdviceMessages.receiverId] else row[AdviceMessages.senderId]
+        }.toSet()
+        Users.selectAll().where {
+            (Users.role eq targetRole) and (Users.id neq userId)
+        }.orderBy(Users.fullName)
+        .map { user ->
+            val name = user[Users.fullName]
+            val initials = name.split(" ").filter { it.isNotEmpty() }
+                .map { it.first().uppercase() }.joinToString("")
+            mapOf(
+                "partnerId" to user[Users.id],
+                "partnerName" to name,
+                "partnerInitials" to initials,
+                "partnerRole" to user[Users.role]
+            )
+        }
+        .filter { (it["partnerId"] as Int) !in existing }
+    }
 }

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2193,6 +2193,55 @@ input::placeholder, textarea::placeholder {
     color: var(--color-primary);
 }
 
+/* Directory section: section header + new-conversation row variant */
+.conv-list__divider {
+    margin: 18px 16px 6px;
+    padding: 0 4px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    color: var(--text-soft);
+    opacity: 0.7;
+}
+.conv-list__divider span { display: inline-block; }
+
+.conv-list__item--new .conv-list__preview {
+    text-transform: capitalize;
+    color: var(--color-primary);
+    font-weight: 500;
+}
+.conv-list__item--active.conv-list__item--new .conv-list__preview {
+    color: var(--color-primary-on);
+    opacity: 0.85;
+}
+.conv-list__new {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-pill);
+    background: transparent;
+    border: 1px dashed var(--color-border-strong);
+    color: var(--text-soft);
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.conv-list__item--new:hover .conv-list__new {
+    background: var(--color-primary);
+    color: var(--color-primary-on);
+    border-color: var(--color-primary);
+}
+.conv-list__item--active .conv-list__new {
+    background: var(--color-primary-on);
+    border-color: var(--color-primary-on);
+    color: var(--color-primary);
+}
+
 /* ---- Main chat panel ---- */
 .chat-main {
     display: flex;

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -56,7 +56,27 @@
                         </a>
                     </li>
                 </ul>
-                <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet.</p>
+                <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet — pick a client below to start one.</p>
+
+                <!-- Directory: every subscriber you haven't messaged yet -->
+                <div class="conv-list__divider" th:if="${directory != null and !directory.isEmpty()}">
+                    <span>All clients</span>
+                </div>
+                <ul class="conv-list" th:if="${directory != null and !directory.isEmpty()}">
+                    <li th:each="p : ${directory}" class="conv-list__row" th:attr="data-name=${p.partnerName}">
+                        <a th:href="|/messages/${p.partnerId}|" class="conv-list__item conv-list__item--new"
+                           th:classappend="${activePartnerId != null and activePartnerId == p.partnerId} ? ' conv-list__item--active' : ''">
+                            <span class="conv-list__avatar">
+                                <span th:text="${p.partnerInitials}">AB</span>
+                            </span>
+                            <div class="conv-list__body">
+                                <span class="conv-list__name" th:text="${p.partnerName}">Name</span>
+                                <span class="conv-list__preview" th:text="${p.partnerRole}">role</span>
+                            </div>
+                            <span class="conv-list__new" aria-hidden="true">+</span>
+                        </a>
+                    </li>
+                </ul>
                 <p class="empty-hint empty-hint--pad chat-search__empty" hidden>No matches for that search.</p>
             </aside>
             <section class="chat-main">

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -60,7 +60,27 @@
                         </a>
                     </li>
                 </ul>
-                <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet.</p>
+                <p class="empty-hint empty-hint--pad" th:if="${partners == null or partners.isEmpty()}">No conversations yet — start one below.</p>
+
+                <!-- Directory: every professional you haven't messaged yet -->
+                <div class="conv-list__divider" th:if="${directory != null and !directory.isEmpty()}">
+                    <span>All professionals</span>
+                </div>
+                <ul class="conv-list" th:if="${directory != null and !directory.isEmpty()}">
+                    <li th:each="p : ${directory}" class="conv-list__row" th:attr="data-name=${p.partnerName}">
+                        <a th:href="|/messages/${p.partnerId}|" class="conv-list__item conv-list__item--new"
+                           th:classappend="${activePartnerId != null and activePartnerId == p.partnerId} ? ' conv-list__item--active' : ''">
+                            <span class="conv-list__avatar">
+                                <span th:text="${p.partnerInitials}">AB</span>
+                            </span>
+                            <div class="conv-list__body">
+                                <span class="conv-list__name" th:text="${p.partnerName}">Name</span>
+                                <span class="conv-list__preview" th:text="${p.partnerRole}">role</span>
+                            </div>
+                            <span class="conv-list__new" aria-hidden="true">+</span>
+                        </a>
+                    </li>
+                </ul>
                 <p class="empty-hint empty-hint--pad chat-search__empty" hidden>No matches for that search.</p>
             </aside>
             <section class="chat-main">


### PR DESCRIPTION
Closes #107.

## Summary
- New "All professionals" (subscriber) / "All clients" (professional) directory section in the messages sidebar listing every user of the opposite role you haven't yet messaged.
- Click any directory row → opens an empty conversation with that user, ready to send the first message. `GET /messages/{partnerId}` already supported this case (fetches partner via `UserService.getById`, returns empty conversation list cleanly).
- Conversations you've already started stay at the top in their own section. A small section divider separates the two.

## Implementation
- `MessageService.getEligibleNewPartners(userId, role)` — queries Users with the opposite role, excludes self + everyone in `AdviceMessages` history.
- `MessageRoutes` (both GET handlers) pass `directory`.
- Both sidebar templates render the new section using the existing `.conv-list__row` markup so the existing JS search filter (substring match on `data-name`) sweeps both sections without any JS change.
- Directory rows show the partner's role as the preview line and a dashed `+` glyph in place of the unread badge — "start a chat" affordance.

## Out of scope
- Subscriber↔subscriber and professional↔professional DMs (requirement was "professionals talk to clients, clients talk to professionals").
- Additional authorization gating — basic messaging stays open to any logged-in user-pair on opposite roles.

## Test plan
- [ ] Sign in as a subscriber with no prior messages — sidebar shows an empty "Conversations" hint, then "All professionals" with every registered professional.
- [ ] Click any professional → opens an empty conversation. Type and send → a new bubble appears, and on next page load the professional moves up into the "Conversations" section.
- [ ] Sign in as a professional — sidebar shows "Conversations" (clients who messaged them) on top, then "All clients" with every other registered subscriber.
- [ ] Search box filters both sections at once.
- [ ] Directory entry that's currently the active conversation (`activePartnerId`) flips to the same sage-fill highlight as conversation entries.