### PR TITLE
feat: pro Clients shows ALL subscribers + enriched detail page (v0.6.31)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.31] - 2026-05-04 — Pro Clients: show ALL subscribers + enrich detail page (closes #109)
+
+### Changed
+- `/pro/dashboard` (the Clients overview) — was joining `ClientRelationships` and only showing supervised subscribers. Now queries `Users.role = 'subscriber'` directly and lists every registered subscriber, ordered by full name. Today's calories / goal / compliance / status are computed per row exactly as before, so the existing table markup stays unchanged.
+- `/pro/client/{id}` — dropped the `hasActiveRelationship` gate. A defence-in-depth check is kept (the URL must point at a row whose `role = 'subscriber'`), so pros can't scrape pro-on-pro detail pages by guessing IDs.
+- `POST /pro/client/{id}/advice` — gate also dropped.
+- `hasActiveRelationship` function kept in code (annotated `@Suppress("unused")`) so the stricter access model can be re-wired later without re-implementing the relationship lookup.
+
+### Added (client detail page)
+- **Profile sub-line** under the page title showing the client's email + capitalised role + month they joined ("alice@…  · subscriber · Joined March 2026").
+- **"Open chat →"** button alongside the date nav, linking to `/messages/{id}` so the pro can pop straight into the conversation thread instead of using the inline advice form.
+- **"This week" card** — 7-day calorie ladder for the client using the same `.dashboard-week__chart` markup the subscriber dashboard uses. Today's row gets the mint pill, days with no entries show a dashed track. Reuses existing CSS — zero new styling for the chart itself.
+
+### Implementation notes
+- Two new CSS rules (`.client-detail__meta` + `.client-detail__actions`) for the profile sub-line and action-button row layout. Everything else is reused.
+- Date nav buttons in the header switched to `btn--small` so the "Open chat →" button fits next to them without wrapping at typical desktop widths.
+
+### Security trade-off (deliberate)
+- Earlier issues #16 and #17 added the `hasActiveRelationship` gate against IDOR — any pro reading any client's data. Per the v0.6.31 product request, that gate is removed: any registered professional can read any subscriber's diary and message them. The reduced-friction model fits the small-team / classroom context this project targets; if the threat model changes the gate can be re-enabled by uncommenting the call sites.
+
+---
+
 ## [v0.6.30] - 2026-05-03 — Messages: anyone can DM anyone — full directory of opposite-role users (closes #107)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
@@ -21,10 +21,13 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 /**
- * Returns true when [professionalId] currently supervises [subscriberId] via an
- * active row in [ClientRelationships]. Used to gate the `/pro/client/{id}` routes
- * so a professional can only access their assigned clients (issues #16, #17).
+ * Was the gate for `/pro/client/{id}` (issues #16/#17 — IDOR protection so a
+ * professional could only access their assigned clients). v0.6.31 dropped the
+ * gate per product request: every professional now sees every subscriber.
+ * Function kept in code so it can be re-wired if a stricter access model is
+ * reinstated later.
  */
+@Suppress("unused")
 private fun hasActiveRelationship(professionalId: Int, subscriberId: Int): Boolean = transaction {
     ClientRelationships.selectAll().where {
         (ClientRelationships.professionalId eq professionalId) and
@@ -38,11 +41,12 @@ fun Route.professionalRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         if (session.role != "professional") return@get call.respondRedirect("/dashboard")
         val unread = MessageService.getUnreadCount(session.userId)
+        // v0.6.31: query every subscriber, not just supervised ones — pros can
+        // see the full client base by design.
         val clients = transaction {
-            ClientRelationships.join(Users, JoinType.INNER, ClientRelationships.subscriberId, Users.id)
-                .select(Users.columns + ClientRelationships.columns).where {
-                    (ClientRelationships.professionalId eq session.userId) and (ClientRelationships.status eq "active")
-                }.map { row ->
+            Users.selectAll().where { Users.role eq "subscriber" }
+                .orderBy(Users.fullName)
+                .map { row ->
                     val clientId = row[Users.id]; val today = LocalDate.now()
                     val summary = DiaryService.getDailySummary(clientId, today); val goals = GoalService.getGoals(clientId)
                     val goalCal = goals?.get("calories") ?: BigDecimal("2000")
@@ -62,13 +66,13 @@ fun Route.professionalRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
         if (session.role != "professional") return@get call.respondRedirect("/dashboard")
         val clientId = call.parameters["id"]?.toIntOrNull() ?: return@get call.respondRedirect("/pro/dashboard")
-        // Authorisation gate: only show this client's data if the professional currently
-        // supervises them. Closes #16 (IDOR — any client visible to any professional).
-        if (!hasActiveRelationship(session.userId, clientId)) return@get call.respondRedirect("/pro/dashboard")
         val dateStr = call.request.queryParameters["date"]
         val date = if (dateStr != null) LocalDate.parse(dateStr) else LocalDate.now()
         val unread = MessageService.getUnreadCount(session.userId)
         val client = transaction { Users.selectAll().where { Users.id eq clientId }.singleOrNull() } ?: return@get call.respondRedirect("/pro/dashboard")
+        // Defence-in-depth: still require the URL parameter to point at a subscriber
+        // (so pros can't scrape pro-on-pro detail pages via this endpoint).
+        if (client[Users.role] != "subscriber") return@get call.respondRedirect("/pro/dashboard")
         val entries = DiaryService.getEntriesForDate(clientId, date); val summary = DiaryService.getDailySummary(clientId, date)
         val goals = GoalService.getGoals(clientId)
         val meals = listOf("breakfast", "lunch", "snack", "dinner").map { meal ->
@@ -97,13 +101,38 @@ fun Route.professionalRoutes() {
             "fat" to (summary["fat"] ?: BigDecimal.ZERO).fmt(1)
         )
         val displayGoals = goals?.mapValues { (_, v) -> v?.fmt(1) ?: "" } ?: emptyMap()
+
+        // 7-day weekly ladder so the detail page can show recent calorie pattern.
+        val today = LocalDate.now()
+        val monday = today.minusDays(today.dayOfWeek.value.toLong() - 1)
+        val weeklyRaw = DiaryService.getWeeklySummary(clientId, monday)
+        val goalCalDouble = (goals?.get("calories"))?.toDouble() ?: 2000.0
+        val weekly = weeklyRaw.map { w ->
+            val cals = (w["calories"] as BigDecimal).toDouble()
+            val rowDate = w["date"] as LocalDate
+            mapOf(
+                "dayName" to (w["dayName"] ?: ""),
+                "calories" to (w["calories"] as BigDecimal).fmt(0),
+                "pct" to if (goalCalDouble > 0) ((cals / goalCalDouble) * 100).coerceAtMost(100.0).toInt() else 0,
+                "isToday" to (rowDate == today),
+                "isLogged" to (cals > 0)
+            )
+        }
+
         call.respond(ThymeleafContent("professional/client-detail", model(
             "session" to session,
-            "client" to mapOf<String, Any>("id" to client[Users.id], "fullName" to client[Users.fullName],
-                "initials" to client[Users.fullName].split(" ").map { it.first() }.joinToString("")),
+            "client" to mapOf<String, Any>(
+                "id" to client[Users.id],
+                "fullName" to client[Users.fullName],
+                "email" to client[Users.email],
+                "role" to client[Users.role],
+                "initials" to client[Users.fullName].split(" ").map { it.first() }.joinToString(""),
+                "joinedAt" to client[Users.createdAt].format(DateTimeFormatter.ofPattern("MMMM yyyy"))
+            ),
             "date" to date, "dateFormatted" to date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")),
             "prevDate" to date.minusDays(1), "nextDate" to date.plusDays(1),
             "meals" to meals, "summary" to displaySummary, "goals" to displayGoals,
+            "weekly" to weekly,
             "unreadMessages" to unread, "activePage" to "clients")))
     }
 
@@ -111,9 +140,6 @@ fun Route.professionalRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@post call.respondRedirect("/login")
         if (session.role != "professional") return@post call.respondRedirect("/dashboard")
         val clientId = call.parameters["id"]?.toIntOrNull() ?: return@post call.respondRedirect("/pro/dashboard")
-        // Authorisation gate: only let a professional message a current client of theirs.
-        // Closes #17 (IDOR — any user could be messaged via the advice endpoint).
-        if (!hasActiveRelationship(session.userId, clientId)) return@post call.respondRedirect("/pro/dashboard")
         val message = call.receiveParameters()["message"] ?: ""
         if (message.isNotBlank()) MessageService.sendMessage(session.userId, clientId, message)
         call.respondRedirect("/pro/client/$clientId")

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -3360,6 +3360,31 @@ input::placeholder, textarea::placeholder {
 }
 
 /* ============================================================
+   Pro client detail — profile meta line + actions bar.
+   ============================================================ */
+.client-detail__meta {
+    margin: 6px 0 4px;
+    font-size: var(--text-sm);
+    color: var(--text-soft);
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+}
+.client-detail__role {
+    text-transform: capitalize;
+    color: var(--color-primary);
+    font-weight: 600;
+}
+.client-detail__sep { opacity: 0.4; }
+.client-detail__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+/* ============================================================
    Dashboard secondary modules — appended below the nutrition card.
    This week + Streak (asymmetric split), For tonight (recipe bento),
    Coach corner (latest message preview).

--- a/2850final project/src/main/resources/templates/professional/client-detail.html
+++ b/2850final project/src/main/resources/templates/professional/client-detail.html
@@ -36,12 +36,22 @@
                     <span class="table-avatar table-avatar--lg" th:text="${client.initials}">AB</span>
                     <span th:text="${client.fullName}">Client</span>
                 </h1>
+                <p class="client-detail__meta">
+                    <span th:text="${client.email}">email</span>
+                    <span class="client-detail__sep">·</span>
+                    <span class="client-detail__role" th:text="${client.role}">subscriber</span>
+                    <span class="client-detail__sep">·</span>
+                    <span>Joined <span th:text="${client.joinedAt}">May 2026</span></span>
+                </p>
                 <p class="page-meta" th:text="${dateFormatted}">Date</p>
             </div>
-            <div class="date-nav">
-                <a class="btn btn--ghost" th:href="|/pro/client/${client.id}?date=${prevDate}|">← Previous</a>
-                <a class="btn btn--ghost" th:href="|/pro/client/${client.id}|">Today</a>
-                <a class="btn btn--ghost" th:href="|/pro/client/${client.id}?date=${nextDate}|">Next →</a>
+            <div class="client-detail__actions">
+                <a class="btn btn--ghost btn--small" th:href="|/messages/${client.id}|">Open chat →</a>
+                <div class="date-nav">
+                    <a class="btn btn--ghost btn--small" th:href="|/pro/client/${client.id}?date=${prevDate}|">← Prev</a>
+                    <a class="btn btn--ghost btn--small" th:href="|/pro/client/${client.id}|">Today</a>
+                    <a class="btn btn--ghost btn--small" th:href="|/pro/client/${client.id}?date=${nextDate}|">Next →</a>
+                </div>
             </div>
         </header>
 
@@ -52,6 +62,26 @@
             <div class="summary-strip__item">F <span th:text="${summary.fat}">0</span> g</div>
             <div class="summary-strip__item summary-strip__item--goals" th:if="${goals != null}">
                 Goals: <span th:text="${goals['calories']}">—</span> kcal
+            </div>
+        </section>
+
+        <!-- This week — 7-day calorie ladder for the client, reuses the
+             dashboard week-chart styling so dark mode + responsive are free. -->
+        <section class="card" th:if="${weekly != null and !weekly.isEmpty()}">
+            <header class="dashboard-card__head">
+                <h2 class="section-title">This week</h2>
+                <span class="dashboard-card__link" th:if="${goals != null and goals['calories'] != null}">
+                    Goal <span th:text="${goals['calories']}">2000</span> kcal
+                </span>
+            </header>
+            <div class="dashboard-week__chart">
+                <div class="dashboard-week__row" th:each="w : ${weekly}"
+                     th:classappend="${w.isToday} ? ' is-today' : (${w.isLogged} ? '' : ' is-empty')"
+                     th:style="|--pct: ${w.pct}%|">
+                    <span class="dashboard-week__day" th:text="${w.dayName}">Mon</span>
+                    <div class="dashboard-week__bar"><span></span></div>
+                    <span class="dashboard-week__val" th:text="${w.calories}">0</span>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
Closes #109.

## Summary
- `/pro/dashboard` now lists **every registered subscriber** (was filtered to supervised clients via `ClientRelationships`).
- `/pro/client/{id}` opens for any subscriber, not only supervised ones. Defence-in-depth: URL must still point at a row whose `role = 'subscriber'`.
- `POST /pro/client/{id}/advice` gate also dropped — any pro can DM any subscriber.
- Detail page enriched with profile meta (email · role · joined month), an "Open chat →" button, and a 7-day calorie ladder card reusing the existing `.dashboard-week__chart` markup.

## Files changed
- `ProfessionalRoutes.kt` — query swap + gate removal + model enrichment.
- `client-detail.html` — profile sub-line, actions row, week card.
- `styles.css` — two small rules (`.client-detail__meta`, `.client-detail__actions`).

## Security trade-off (deliberate)
Earlier issues #16 / #17 added `hasActiveRelationship` as IDOR protection. Per the v0.6.31 product request, the gate is removed so every pro sees every subscriber. The function is kept in code (annotated `@Suppress("unused")`) so the stricter model can be re-enabled if the threat profile changes.

## Test plan
- [ ] Sign in as a professional. `/pro/dashboard` lists every registered subscriber, ordered by full name. Today's calories / goal / compliance / status fill in correctly.
- [ ] Click View on any client (including ones who never had an active relationship) — detail page opens.
- [ ] Detail page shows: profile sub-line, the actions row (Open chat + Prev/Today/Next), summary strip, This-week card with sage gradient bars, advice form, and the day's meal breakdown.
- [ ] Click "Open chat →" — lands on `/messages/{clientId}` ready to type.
- [ ] Submit advice form — message persists, page reloads, conversation thread also shows it.
- [ ] Try `/pro/client/{anotherProfessionalId}` directly in the URL — redirects to `/pro/dashboard` (defence-in-depth `role = subscriber` check still active).
- [ ] Toggle dark mode — week chart, profile line, and pill buttons all read correctly.