### PR TITLE
fix: login page scrolls on short viewports — register form reachable (v0.6.32)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.32] - 2026-05-04 — Login page scrolls on short viewports — register form no longer cut off (closes #111)
+
+### Fixed
+- `.auth-body` was `display: flex; align-items: center; justify-content: center; overflow: hidden`. On a viewport shorter than the register form (~800px tall — small laptops or partial-height browser windows), the form overflowed equally off the top and bottom and `overflow: hidden` blocked page scroll, so users physically couldn't reach the "Create account" button.
+- Switched to a column flex with `align-items: center` (horizontal centering) and `overflow-x: hidden` only. Vertical centering moves to `.auth-shell { margin: auto 0 }` — a flexbox idiom that centers when there's slack but top-anchors when content exceeds the container. Tall viewports still see the card centered; short viewports now top-anchor it and the page scrolls naturally to the submit button.
+
+### Why not just `overflow-y: auto`
+That creates an internal scroll container inside the body, which makes the animated blob pseudo-elements scroll with the form (they're absolutely positioned to the body). The `overflow-x: hidden + page-level scroll + margin: auto 0` recipe keeps the blobs static while the form scrolls.
+
+---
+
 ## [v0.6.31] - 2026-05-04 — Pro Clients: show ALL subscribers + enrich detail page (closes #109)
 
 ### Changed

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -500,14 +500,20 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
    Auth — login page hero + animated mesh background
    ============================================================ */
 .auth-body {
+    /* Column flex + horizontal centering. Vertical centering happens via
+       auth-shell's `margin: auto 0` — that pattern centers when there's
+       extra space and top-anchors when content exceeds the viewport, so
+       short browser windows still let the user scroll to "Create account".
+       overflow-x: hidden clips the animated blob pseudo-elements without
+       breaking page scroll. */
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
     min-height: 100vh;
     padding: 32px;
     background: var(--color-bg);
     position: relative;
-    overflow: hidden;
+    overflow-x: hidden;
     isolation: isolate;
 }
 
@@ -589,6 +595,10 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 .auth-shell {
     width: 100%;
     max-width: 440px;
+    /* `margin: auto 0` in a flex column = vertical centering when there's
+       slack, top-anchored when content overflows. Lets short viewports
+       scroll to reach the "Create account" button. */
+    margin: auto 0;
     animation: fade-up var(--dur-slow) var(--ease-out) both;
     position: relative;
     z-index: 1;


### PR DESCRIPTION
Closes #111.

## Summary
The register form was being clipped on short viewports. `.auth-body` was `display: flex; align-items: center; overflow: hidden`, so:
1. Centering pushed the form's top edge above the viewport (`align-items: center` overflows equally on both sides).
2. `overflow: hidden` blocked the page from scrolling to recover.

Net effect: users with smaller laptops / partial-height windows literally couldn't click "Create account".

## Fix
- `.auth-body` → `display: flex; flex-direction: column; align-items: center; overflow-x: hidden` (no `justify-content: center`, no `overflow: hidden`).
- `.auth-shell` → `margin: auto 0`. Flexbox idiom that vertically centers when there's slack and top-anchors when content exceeds the container. Tall viewports stay centered; short viewports scroll naturally.
- `overflow-x: hidden` keeps clipping the absolutely-positioned blob pseudo-elements horizontally so they don't add a sideways scrollbar.

## Test plan
- [ ] Open `/login`, switch to Register tab.
- [ ] Resize the browser window vertically to ~700px — page now scrolls; "Create account" button reachable.
- [ ] Resize to >900px — card centers vertically as before.
- [ ] Animated sage / clay / berry blobs still drift in the background, still don't cause horizontal scroll.
- [ ] Light + dark theme both behave the same.