### PR TITLE
feat: diary visual food picker grid + 37 more foods (v0.6.33)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.33] - 2026-05-04 — Diary "Add food" visual picker + 37 more foods (closes #113)
+
+### Added
+- **37 commonly-eaten foods** seeded via a new `SeedData.backfillExtraFoods()` runner so live DBs (Render) get them on next boot without a re-seed. Same idempotent pattern as `backfillExtraRecipes`. Coverage:
+  - Fruits: Apple, Orange, Strawberries, Blueberries, Mango, Pineapple, Grapes, Watermelon, Lemon
+  - Vegetables: Carrot, Spinach, Bell Pepper, Onion, Mushroom, Cauliflower, Corn
+  - Grains: White Rice, Quinoa, Pasta, Bagel
+  - Proteins: Beef (lean ground), Pork (lean), Turkey Breast, Tuna (canned), Shrimp, Black Beans, Chickpeas
+  - Dairy: Milk (2%), Cheddar Cheese, Cottage Cheese
+  - Snacks: Peanut Butter, Hummus, Dark Chocolate, Popcorn
+  - Beverages: Coffee (black), Orange Juice, Smoothie (fruit)
+- `foodEmoji(name)` and `foodTone(category)` helpers in `Format.kt` — same shape as the existing `recipeCoverEmoji` / `recipeCoverTone`. Maps 50+ keywords to glyphs (apple → 🍎, broccoli → 🥦, salmon → 🐟, ...) and four categories to brand cover tones (Fruits → berry, Vegetables → sage, Grains → oat, Proteins → clay).
+
+### Changed
+- **`/api/food-search?q=`** — when `q` is blank, returns the full library (capped at 60 rows) ordered by name. Used by the new picker grid that opens fully populated. Each row also returns `emoji` and `tone` so the front-end renders branded cards in one round-trip.
+- **Diary "Add food" modal** rewritten:
+  - Old: `Search foods` label + `Type at least 3 letters…` hint + a hidden text-button list. Users had to know what to type before anything appeared.
+  - New: a `food-picker__search` pill input + a `food-picker__grid` of visual food cards, each with the food emoji on a category-tinted gradient cover + name + kcal/100g. Click any card to select it (sage focus ring + filled border) and unlock the Add-to-diary submit button.
+  - Filtering is client-side once the initial fetch lands — no server round-trip per keystroke. Empty input shows everything; empty result shows a centered "No foods match" hint.
+  - Cards use Liquid Glass surface (`var(--glass-bg-warm)` + `backdrop-filter: var(--glass-blur)`) so they read as thick translucent tiles over the modal's glass panel.
+- `initFoodSearch()` → `initFoodPicker()` in `app.js`. Lazy-loads the food list on first modal open via a `MutationObserver` watching `.is-open` on the modal element — `/diary` page renders don't pay for the list until the user actually clicks Add food.
+
+### Implementation notes
+- Old CSS class `.food-search-results` removed; replaced by `.food-picker / .food-picker__search / .food-picker__grid / .food-picker__empty / .food-card / .food-card__cover / .food-card__cover--<tone> / .food-card__emoji / .food-card__name / .food-card__cal`.
+- Cover tones are `recipe-card__cover--*` cousins — same gradient recipe (`linear-gradient(135deg, <color-bg>, <color-soft>)`) so dark mode flips automatically via the v0.6.14 token work.
+- `foodEmoji` falls back to a generic 🍽️ plate when no keyword matches, so future foods added without explicit emoji handling still render cleanly.
+
+---
+
 ## [v0.6.32] - 2026-05-04 — Login page scrolls on short viewports — register form no longer cut off (closes #111)
 
 ### Fixed

--- a/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/config/Database.kt
@@ -75,6 +75,9 @@ fun Application.configureDatabase() {
     // Idempotent — inserts the v0.6.8 recipe pack (titles checked first), so
     // the live Render PostgreSQL gets six new recipes without a fresh seed.
     SeedData.backfillExtraRecipes()
+    // Idempotent — inserts the v0.6.33 food pack (~37 commonly-eaten foods) so
+    // the diary picker has variety on existing live DBs without a re-seed.
+    SeedData.backfillExtraFoods()
     // Idempotent — keeps the demo account (alice@email.com) populated for
     // *today* so the dashboard never opens to a hostile zero state.
     SeedData.ensureAliceHasTodayEntries()

--- a/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/diary/DiaryService.kt
@@ -113,17 +113,32 @@ object DiaryService {
         input.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     /**
-     * Case-insensitive substring search over `food_items.name`. Limits to 20
-     * rows for the autocomplete dropdown. The user-supplied [query] is
-     * wildcard-escaped via [escapeLikePattern] so `%` cannot match the entire
-     * table (issue #19).
-     *
-     * @return one map per match, keyed by `id`, `name`, `category`, `calories`.
+     * Case-insensitive substring search over `food_items.name`. When [query] is
+     * blank, returns the full library (capped at 60) — powers the visual food
+     * picker grid that opens with everything visible instead of waiting for
+     * the user to type. Returns `id` / `name` / `category` / `calories` plus
+     * `emoji` + `tone` so the front-end can render brand-tinted cards without
+     * a second round-trip.
      */
     fun searchFood(query: String): List<Map<String, Any>> = transaction {
-        val safe = escapeLikePattern(query.lowercase())
-        FoodItems.selectAll().where { FoodItems.name.lowerCase() like "%$safe%" }.limit(20).map { row ->
-            mapOf("id" to row[FoodItems.id], "name" to row[FoodItems.name], "category" to row[FoodItems.category], "calories" to row[FoodItems.caloriesPer100g])
+        val rows = if (query.isBlank()) {
+            FoodItems.selectAll().orderBy(FoodItems.name).limit(60)
+        } else {
+            val safe = escapeLikePattern(query.lowercase())
+            FoodItems.selectAll().where { FoodItems.name.lowerCase() like "%$safe%" }
+                .orderBy(FoodItems.name).limit(20)
+        }
+        rows.map { row ->
+            val name = row[FoodItems.name]
+            val category = row[FoodItems.category]
+            mapOf(
+                "id" to row[FoodItems.id],
+                "name" to name,
+                "category" to category,
+                "calories" to row[FoodItems.caloriesPer100g],
+                "emoji" to com.goodfood.util.foodEmoji(name),
+                "tone" to com.goodfood.util.foodTone(category)
+            )
         }
     }
 }

--- a/2850final project/src/main/kotlin/com/goodfood/seed/SeedData.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/seed/SeedData.kt
@@ -212,6 +212,82 @@ object SeedData {
         }
     }
 
+    /**
+     * v0.6.33 — extra commonly-eaten foods so the diary "Add food" picker has
+     * meaningful variety (apple, orange, beef, milk, peanut butter, ...). Same
+     * shape as the original [FoodSeed] inserts but applied as a backfill: only
+     * inserts foods whose `name` doesn't already exist, so repeated boots are
+     * idempotent.
+     */
+    private data class ExtraFood(val name: String, val cat: String, val cal: String, val prot: String, val carb: String, val fat: String, val fiber: String? = null, val sugar: String? = null)
+    private val extraFoods: List<ExtraFood> = listOf(
+        // Fruits
+        ExtraFood("Apple", "Fruits", "52", "0.3", "14", "0.2", "2.4", "10.4"),
+        ExtraFood("Orange", "Fruits", "47", "0.9", "12", "0.1", "2.4", "9.4"),
+        ExtraFood("Strawberries", "Fruits", "32", "0.7", "8", "0.3", "2", "4.9"),
+        ExtraFood("Blueberries", "Fruits", "57", "0.7", "14", "0.3", "2.4", "10"),
+        ExtraFood("Mango", "Fruits", "60", "0.8", "15", "0.4", "1.6", "13.7"),
+        ExtraFood("Pineapple", "Fruits", "50", "0.5", "13", "0.1", "1.4", "9.9"),
+        ExtraFood("Grapes", "Fruits", "67", "0.6", "17", "0.4", "0.9", "16.3"),
+        ExtraFood("Watermelon", "Fruits", "30", "0.6", "8", "0.2", "0.4", "6.2"),
+        ExtraFood("Lemon", "Fruits", "29", "1.1", "9", "0.3", "2.8", "2.5"),
+        // Vegetables
+        ExtraFood("Carrot", "Vegetables", "41", "0.9", "10", "0.2", "2.8", "4.7"),
+        ExtraFood("Spinach", "Vegetables", "23", "2.9", "3.6", "0.4", "2.2", "0.4"),
+        ExtraFood("Bell Pepper", "Vegetables", "31", "1", "6", "0.3", "2.1", "4.2"),
+        ExtraFood("Onion", "Vegetables", "40", "1.1", "9", "0.1", "1.7", "4.2"),
+        ExtraFood("Mushroom", "Vegetables", "22", "3.1", "3.3", "0.3", "1", "2"),
+        ExtraFood("Cauliflower", "Vegetables", "25", "1.9", "5", "0.3", "2", "1.9"),
+        ExtraFood("Corn", "Vegetables", "86", "3.2", "19", "1.4", "2.7", "6.3"),
+        // Grains
+        ExtraFood("White Rice", "Grains", "130", "2.7", "28", "0.3", "0.4", "0.1"),
+        ExtraFood("Quinoa", "Grains", "120", "4.4", "21", "1.9", "2.8", "0.9"),
+        ExtraFood("Pasta", "Grains", "131", "5", "25", "1.1", "1.8", "0.6"),
+        ExtraFood("Bagel", "Grains", "245", "10", "48", "1.5", "2", "5"),
+        // Meat / fish
+        ExtraFood("Beef (lean ground)", "Meat", "250", "26", "0", "15", "0", "0"),
+        ExtraFood("Pork (lean)", "Meat", "143", "21", "0", "6", "0", "0"),
+        ExtraFood("Turkey Breast", "Meat", "135", "30", "0", "1", "0", "0"),
+        ExtraFood("Tuna (canned)", "Fish", "132", "28", "0", "1", "0", "0"),
+        ExtraFood("Shrimp", "Fish", "99", "24", "0.2", "0.3", "0", "0"),
+        // Legumes
+        ExtraFood("Black Beans", "Legumes", "132", "8.9", "23.7", "0.5", "8.7", "0.3"),
+        ExtraFood("Chickpeas", "Legumes", "164", "8.9", "27", "2.6", "7.6", "4.8"),
+        // Dairy
+        ExtraFood("Milk (2%)", "Dairy", "50", "3.3", "5", "2", "0", "5"),
+        ExtraFood("Cheddar Cheese", "Dairy", "402", "25", "1.3", "33", "0", "0.5"),
+        ExtraFood("Cottage Cheese", "Dairy", "98", "11", "3.4", "4.3", "0", "2.7"),
+        // Snacks
+        ExtraFood("Peanut Butter", "Snacks", "588", "25", "20", "50", "6", "9"),
+        ExtraFood("Hummus", "Snacks", "166", "8", "14", "10", "6", "0.3"),
+        ExtraFood("Dark Chocolate", "Snacks", "598", "7.8", "46", "43", "11", "24"),
+        ExtraFood("Popcorn", "Snacks", "387", "12", "78", "4.5", "14.5", "0.9"),
+        // Beverages
+        ExtraFood("Coffee (black)", "Beverages", "1", "0.1", "0", "0", "0", "0"),
+        ExtraFood("Orange Juice", "Beverages", "45", "0.7", "10", "0.2", "0.2", "8.4"),
+        ExtraFood("Smoothie (fruit)", "Beverages", "82", "1.5", "19", "0.5", "1.8", "14")
+    )
+
+    fun backfillExtraFoods() {
+        transaction {
+            val now = LocalDateTime.now()
+            for (f in extraFoods) {
+                val exists = FoodItems.selectAll().where { FoodItems.name eq f.name }.count() > 0L
+                if (exists) continue
+                FoodItems.insert {
+                    it[name] = f.name; it[category] = f.cat
+                    it[caloriesPer100g] = BigDecimal(f.cal)
+                    it[proteinPer100g] = BigDecimal(f.prot)
+                    it[carbsPer100g] = BigDecimal(f.carb)
+                    it[fatPer100g] = BigDecimal(f.fat)
+                    it[fiberPer100g] = f.fiber?.let { v -> BigDecimal(v) }
+                    it[sugarPer100g] = f.sugar?.let { v -> BigDecimal(v) }
+                    it[createdAt] = now
+                }
+            }
+        }
+    }
+
     fun backfillExtraRecipes() {
         transaction {
             val sarah = Users.selectAll().where { Users.email eq "sarah@clinic.com" }.singleOrNull() ?: return@transaction

--- a/2850final project/src/main/kotlin/com/goodfood/util/Format.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/util/Format.kt
@@ -84,3 +84,89 @@ fun recipeCoverTone(title: String): String {
     val idx = ((title.hashCode().toLong() and 0xFFFF) % tones.size).toInt()
     return tones[idx]
 }
+
+/**
+ * Pick a food emoji for a food-item card from a keyword scan over its name.
+ * Used by the diary "Add food" picker so each card has a recognisable
+ * visual without needing real photographs. Falls through to a generic
+ * plate when nothing matches.
+ */
+fun foodEmoji(name: String): String {
+    val n = name.lowercase()
+    return when {
+        "apple" in n -> "🍎"
+        "banana" in n -> "🍌"
+        "orange" in n -> "🍊"
+        "grape" in n -> "🍇"
+        "strawberr" in n -> "🍓"
+        "blueberr" in n -> "🫐"
+        "watermelon" in n -> "🍉"
+        "pineapple" in n -> "🍍"
+        "mango" in n -> "🥭"
+        "lemon" in n -> "🍋"
+        "avocado" in n -> "🥑"
+        "tomato" in n -> "🍅"
+        "carrot" in n -> "🥕"
+        "broccoli" in n -> "🥦"
+        "cauliflower" in n -> "🥦"
+        "cucumber" in n -> "🥒"
+        "spinach" in n || "salad green" in n || "lettuce" in n -> "🥬"
+        "sweet potato" in n -> "🍠"
+        "potato" in n -> "🥔"
+        "onion" in n -> "🧅"
+        "garlic" in n -> "🧄"
+        "pepper" in n -> "🫑"
+        "corn" in n -> "🌽"
+        "mushroom" in n -> "🍄"
+        "rice" in n -> "🍚"
+        "bagel" in n -> "🥯"
+        "bread" in n || "toast" in n -> "🍞"
+        "pasta" in n || "noodle" in n || "spaghetti" in n -> "🍝"
+        "oat" in n || "oatmeal" in n -> "🥣"
+        "quinoa" in n -> "🌾"
+        "egg" in n -> "🥚"
+        "milk" in n -> "🥛"
+        "cheese" in n || "cheddar" in n || "cottage" in n -> "🧀"
+        "butter" in n && "peanut" !in n -> "🧈"
+        "yogurt" in n -> "🍦"
+        "chicken" in n || "turkey" in n -> "🍗"
+        "beef" in n || "steak" in n || "burger" in n -> "🥩"
+        "pork" in n || "bacon" in n || "ham" in n -> "🥓"
+        "salmon" in n || "tuna" in n || "fish" in n -> "🐟"
+        "shrimp" in n || "prawn" in n -> "🦐"
+        "tofu" in n || "tempeh" in n -> "🍢"
+        "lentil" in n || "chickpea" in n || "bean" in n -> "🫘"
+        "almond" in n || "nut" in n || "peanut" in n -> "🥜"
+        "chia" in n || "seed" in n -> "🌱"
+        "olive" in n || "oil" in n -> "🫒"
+        "honey" in n -> "🍯"
+        "chocolate" in n -> "🍫"
+        "popcorn" in n -> "🍿"
+        "hummus" in n -> "🥣"
+        "tea" in n -> "🍵"
+        "coffee" in n -> "☕"
+        "smoothie" in n || "juice" in n -> "🧃"
+        "water" in n -> "💧"
+        else -> "🍽️"
+    }
+}
+
+/**
+ * Map a food category to one of the four brand cover tones used by recipe
+ * cards (sage / oat / clay / berry). Tones live in CSS as
+ * `.recipe-card__cover--<tone>` with light/dark gradients via existing
+ * brand tokens, so the food picker reuses them for free.
+ */
+fun foodTone(category: String): String = when (category.lowercase()) {
+    "fruits" -> "berry"
+    "vegetables" -> "sage"
+    "grains" -> "oat"
+    "meat", "fish" -> "clay"
+    "legumes" -> "sage"
+    "dairy" -> "oat"
+    "nuts", "seeds" -> "clay"
+    "oils" -> "sage"
+    "snacks" -> "berry"
+    "beverages" -> "sage"
+    else -> "sage"
+}

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2654,37 +2654,106 @@ input::placeholder, textarea::placeholder {
 }
 .modal__close:hover { background: var(--color-surface-alt); color: var(--text-strong); }
 
-.food-search-results {
-    max-height: 240px;
-    overflow-y: auto;
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-sm);
-    margin-top: -8px;
-    margin-bottom: 8px;
-    display: none;
-    background: var(--color-surface);
-    box-shadow: var(--shadow-xs);
+/* ============================================================
+   Food picker — visual grid inside the diary "Add food" modal.
+   Each card is an emoji on a category-tinted gradient + name + kcal/100g.
+   Reuses the recipe-card cover tones so dark mode flips for free.
+   ============================================================ */
+.food-picker {
+    margin-bottom: 4px;
 }
-.food-search-results.is-visible {
-    display: block;
-    animation: fade-in var(--dur-fast) var(--ease) both;
-}
-.food-search-results button {
-    display: block;
+.food-picker__search {
     width: 100%;
-    text-align: left;
-    padding: 12px 14px;
-    border: none;
-    border-bottom: 1px solid var(--color-border-soft);
+    padding: 10px 14px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-pill);
     background: var(--color-surface);
-    color: var(--text);
+    color: var(--text-strong);
     font: inherit;
     font-size: var(--text-body);
-    cursor: pointer;
-    transition: background var(--dur-fast) var(--ease);
+    margin-bottom: 12px;
+    transition: border-color var(--dur-fast) var(--ease);
 }
-.food-search-results button:hover { background: var(--color-primary-soft); }
-.food-search-results button:last-child { border-bottom: none; }
+.food-picker__search:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: var(--ring);
+}
+.food-picker__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 4px;
+    margin: 0 -4px;
+}
+.food-picker__empty {
+    margin: 12px 4px 0;
+    color: var(--text-soft);
+    font-size: var(--text-sm);
+    text-align: center;
+}
+
+.food-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 8px 14px;
+    background: var(--glass-bg-warm);
+    backdrop-filter: var(--glass-blur);
+    -webkit-backdrop-filter: var(--glass-blur);
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    text-align: center;
+    font: inherit;
+    color: inherit;
+    transition: border-color var(--dur-fast) var(--ease),
+                box-shadow var(--dur-fast) var(--ease),
+                transform var(--dur-fast) var(--ease);
+}
+.food-card:hover {
+    border-color: var(--color-border-strong);
+    box-shadow: var(--shadow-sm);
+    transform: translateY(-1px);
+}
+.food-card.is-selected {
+    border-color: var(--color-primary);
+    box-shadow: var(--ring);
+}
+.food-card__cover {
+    width: 56px;
+    height: 56px;
+    border-radius: var(--radius-pill);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.food-card__cover--sage  { background: linear-gradient(135deg, var(--color-sage-bg), var(--color-sage-soft)); }
+.food-card__cover--clay  { background: linear-gradient(135deg, var(--color-clay-bg), var(--color-clay-soft)); }
+.food-card__cover--oat   { background: linear-gradient(135deg, var(--color-cream-warm), var(--color-oat)); }
+.food-card__cover--berry { background: linear-gradient(135deg, var(--color-berry-soft), var(--color-berry-tint)); }
+
+.food-card__emoji {
+    font-size: 30px;
+    line-height: 1;
+    filter: var(--emoji-shadow);
+}
+.food-card__name {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-strong);
+    line-height: 1.2;
+    word-break: break-word;
+}
+.food-card__cal {
+    font-size: 11px;
+    color: var(--text-soft);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}
 
 /* ============================================================
    Toast

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -82,62 +82,87 @@
         });
     }
 
-    /* ---- Food search (/api/food-search?q=) ---- */
-    function initFoodSearch() {
+    /* ---- Food picker (visual grid) ----
+       Replaces the old type-3-letters search. Modal opens → grid loads with
+       every food (server caps at 60). Search input filters live. Click a
+       card → marks it selected, sets the hidden foodItemId, enables submit. */
+    function initFoodPicker() {
         var input = document.getElementById("food-search-input");
-        var results = document.getElementById("food-search-results");
+        var grid = document.getElementById("food-search-results");
+        var emptyEl = document.querySelector(".food-picker__empty");
         var foodIdInput = document.getElementById("modal-food-item-id");
         var submitBtn = document.getElementById("modal-submit");
-        if (!input || !results) return;
+        var modal = document.getElementById("add-food-modal");
+        if (!input || !grid) return;
 
-        // Minimum query length: 3 — matches the inline hint shown next to the
-        // search input in subscriber/diary.html. Bumping this here without also
-        // updating that hint would re-introduce the original UX problem
-        // (testers typing 1-2 chars and seeing nothing happen — issue #38).
-        var MIN_QUERY_LEN = 3;
-        var t = null;
-        input.addEventListener("input", function () {
-            clearTimeout(t);
-            var q = input.value.trim();
-            if (q.length < MIN_QUERY_LEN) {
-                results.innerHTML = "";
-                results.classList.remove("is-visible");
+        var allFoods = [];
+        var loaded = false;
+
+        function renderGrid(items) {
+            grid.innerHTML = "";
+            if (!items || !items.length) {
+                if (emptyEl) emptyEl.hidden = false;
                 return;
             }
-            t = setTimeout(function () {
-                fetch("/api/food-search?q=" + encodeURIComponent(q))
-                    .then(function (r) {
-                        if (!r.ok) throw new Error("search failed");
-                        return r.json();
-                    })
-                    .then(function (items) {
-                        results.innerHTML = "";
-                        if (!items || !items.length) {
-                            results.classList.remove("is-visible");
-                            return;
-                        }
-                        items.forEach(function (item) {
-                            var b = document.createElement("button");
-                            b.type = "button";
-                            b.setAttribute("role", "option");
-                            b.textContent = item.name + " — " + item.calories + " kcal/100g";
-                            b.addEventListener("click", function () {
-                                if (foodIdInput) foodIdInput.value = String(item.id);
-                                if (submitBtn) submitBtn.disabled = false;
-                                input.value = item.name;
-                                results.innerHTML = "";
-                                results.classList.remove("is-visible");
-                            });
-                            results.appendChild(b);
-                        });
-                        results.classList.add("is-visible");
-                    })
-                    .catch(function () {
-                        results.innerHTML = "";
-                        results.classList.remove("is-visible");
-                    });
-            }, 250);
+            if (emptyEl) emptyEl.hidden = true;
+            items.forEach(function (item) {
+                var card = document.createElement("button");
+                card.type = "button";
+                card.className = "food-card";
+                card.setAttribute("role", "option");
+                card.setAttribute("data-food-id", String(item.id));
+                card.setAttribute("data-food-name", item.name.toLowerCase());
+                card.innerHTML =
+                    '<span class="food-card__cover food-card__cover--' + item.tone + '">' +
+                        '<span class="food-card__emoji" aria-hidden="true">' + item.emoji + '</span>' +
+                    '</span>' +
+                    '<span class="food-card__name"></span>' +
+                    '<span class="food-card__cal"></span>';
+                card.querySelector(".food-card__name").textContent = item.name;
+                card.querySelector(".food-card__cal").textContent =
+                    Math.round(parseFloat(item.calories)) + " kcal/100g";
+                card.addEventListener("click", function () {
+                    grid.querySelectorAll(".food-card.is-selected")
+                        .forEach(function (c) { c.classList.remove("is-selected"); });
+                    card.classList.add("is-selected");
+                    if (foodIdInput) foodIdInput.value = String(item.id);
+                    if (submitBtn) submitBtn.disabled = false;
+                });
+                grid.appendChild(card);
+            });
+        }
+
+        function loadAll() {
+            if (loaded) return Promise.resolve();
+            return fetch("/api/food-search?q=")
+                .then(function (r) { return r.ok ? r.json() : []; })
+                .then(function (items) {
+                    allFoods = items || [];
+                    loaded = true;
+                    renderGrid(allFoods);
+                })
+                .catch(function () { allFoods = []; loaded = true; renderGrid([]); });
+        }
+
+        // Live filter — substring match on food name. No min query length;
+        // empty input shows everything. Filtering is client-side once the
+        // initial fetch lands.
+        input.addEventListener("input", function () {
+            var q = input.value.trim().toLowerCase();
+            if (!q) { renderGrid(allFoods); return; }
+            renderGrid(allFoods.filter(function (item) {
+                return item.name.toLowerCase().indexOf(q) !== -1;
+            }));
         });
+
+        // Lazy-load on first modal open (so /diary doesn't pay for the food
+        // list on every page render). Watch for the .is-open class flip.
+        if (modal) {
+            var observer = new MutationObserver(function () {
+                if (modal.classList.contains("is-open") && !loaded) loadAll();
+            });
+            observer.observe(modal, { attributes: true, attributeFilter: ["class"] });
+        }
     }
 
     /* ---- Star rating ---- */
@@ -431,7 +456,7 @@
     document.addEventListener("DOMContentLoaded", function () {
         initAuthTabs();
         initFoodModal();
-        initFoodSearch();
+        initFoodPicker();
         initStarRating();
         initTheme();
         initSidebarDrawer();

--- a/2850final project/src/main/resources/templates/subscriber/diary.html
+++ b/2850final project/src/main/resources/templates/subscriber/diary.html
@@ -93,14 +93,15 @@
             <input type="hidden" name="mealType" id="modal-meal-type" value="breakfast"/>
             <input type="hidden" name="foodItemId" id="modal-food-item-id" value=""/>
 
-            <label class="field">
-                <span class="field__label">Search foods</span>
-                <input type="search" id="food-search-input" class="js-food-search"
-                       placeholder="Type at least 3 letters…" autocomplete="off"
-                       aria-describedby="food-search-hint"/>
-                <p id="food-search-hint" class="field-hint">Type at least 3 letters to search. Try <em>ban</em>, <em>chi</em>, or <em>oat</em>.</p>
-            </label>
-            <div id="food-search-results" class="food-search-results" role="listbox"></div>
+            <div class="food-picker">
+                <label class="sr-only" for="food-search-input">Search foods</label>
+                <input type="search" id="food-search-input" class="food-picker__search js-food-picker"
+                       placeholder="Search foods…" autocomplete="off"/>
+                <div id="food-search-results" class="food-picker__grid" role="listbox" aria-label="Foods">
+                    <!-- Cards rendered by initFoodPicker() in app.js -->
+                </div>
+                <p class="food-picker__empty" hidden>No foods match that search.</p>
+            </div>
 
             <label class="field">
                 <span class="field__label">Amount (grams)</span>


### PR DESCRIPTION
Closes #113.

## Summary
- **37 commonly-eaten foods** added to the seed library via a new idempotent `backfillExtraFoods()` runner. Live DBs (Render) get them on next boot. Coverage spans every meal category — Apple, Orange, Spinach, Quinoa, Beef, Milk, Peanut Butter, Coffee, etc.
- **Visual food picker** replaces the old type-3-letters search. Modal opens with a grid of branded cards (food emoji on a category-tinted gradient + name + kcal/100g). Click selects, search filters live, submit unlocks.
- New `foodEmoji` / `foodTone` helpers in `Format.kt` mirror the existing `recipeCoverEmoji` / `recipeCoverTone` pattern.

## Backend changes
- `DiaryService.searchFood` returns the full library (capped at 60) when `q` is blank, plus `emoji` + `tone` per row.
- `SeedData.backfillExtraFoods()` only inserts foods not already present, by name.
- `Database.kt` boot sequence wires the new backfill in after `backfillExtraRecipes`.

## Frontend changes
- `initFoodSearch` → `initFoodPicker` in `app.js`. Lazy-loads on first modal open via a `MutationObserver` on `.is-open` so `/diary` page renders don't pay for the food list until the user clicks Add food. Filtering is client-side once the initial fetch lands.
- Picker uses Liquid Glass surfaces (`var(--glass-bg-warm)` + `backdrop-filter`) and reuses the recipe-cover tone gradients (`--sage`/`--oat`/`--clay`/`--berry`), so dark mode flips automatically.

## Test plan
- [ ] Visit `/diary`, click `Add food` on any meal — modal opens with a grid of food cards (no typing required).
- [ ] Search box filters live: type "ap" → Apple stays, others hide. Clear → everything reappears.
- [ ] Click any food card — sage focus ring around it, submit button enables, foodItemId hidden field gets the right value.
- [ ] Submit form → entry persists and the diary shows it under the right meal.
- [ ] Toggle dark mode — every card flips: emoji on darker tinted gradient, sage glow on selected card still visible.
- [ ] Live Render boot: existing prod DB picks up the 37 new foods without manual intervention.