### PR TITLE
feat: pro Clients compliance band — flag over-eating, uncap percentage (v0.6.34)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.34] - 2026-05-04 — Pro Clients: tighter compliance band, over-eating surfaces honestly (closes #115)
+
+### Changed
+- The Clients overview was capping compliance at 100 and using a single threshold (`pct >= 60`) for the Status pill. A client at 150% of goal therefore showed `100%` Compliance and `On Track` Status — pros lost all visibility into over-eating clients. The threshold of 60% was also too lenient on the under-eating side.
+- Replaced with a band rule:
+  - `compliance < 80%` → **Needs Attention** (under-eating)
+  - `80% ≤ compliance ≤ 100%` → **On Track**
+  - `compliance > 100%` → **Needs Attention** (over-eating)
+- Compliance percentage is no longer capped — the table now shows the real value (e.g. `150%`) so a pro can see how far past goal a client is at a glance.
+- Added `complianceVisual` (capped at 100) on the model so the inline progress-bar's `width` doesn't overflow the track even when the actual percentage is over 100%.
+
+### Not changed
+- Same `status-pill--warn` style for both under-eating and over-eating cases — per request, both surface as just "Needs Attention". The unbalanced percentage in the adjacent cell carries the under/over signal.
+
+---
+
 ## [v0.6.33] - 2026-05-04 — Diary "Add food" visual picker + 37 more foods (closes #113)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/professional/ProfessionalRoutes.kt
@@ -50,11 +50,18 @@ fun Route.professionalRoutes() {
                     val clientId = row[Users.id]; val today = LocalDate.now()
                     val summary = DiaryService.getDailySummary(clientId, today); val goals = GoalService.getGoals(clientId)
                     val goalCal = goals?.get("calories") ?: BigDecimal("2000")
+                    // v0.6.34 — NOT capped at 100, so over-eating clients (e.g. 150%)
+                    // surface as such instead of being silently clamped to 100% / On Track.
                     val pct = if (goalCal > BigDecimal.ZERO) summary["calories"]!!.multiply(BigDecimal(100)).divide(goalCal, 0, RoundingMode.HALF_UP).toInt() else 0
+                    // Status band: under 80% = under-eating, over 100% = over-eating —
+                    // both flag "Needs Attention". 80–100% is the On-Track sweet spot.
+                    val status = if (pct in 80..100) "On Track" else "Needs Attention"
                     mapOf<String, Any>("id" to clientId, "fullName" to row[Users.fullName],
                         "initials" to row[Users.fullName].split(" ").map { it.first() }.joinToString(""),
                         "calories" to (summary["calories"] ?: BigDecimal.ZERO).fmt(0), "goalCalories" to goalCal.fmt(0),
-                        "compliance" to pct.coerceAtMost(100), "status" to if (pct >= 60) "On Track" else "Needs Attention")
+                        "compliance" to pct,
+                        "complianceVisual" to pct.coerceAtMost(100),  // for the inline progress bar width
+                        "status" to status)
                 }
         }
         call.respond(ThymeleafContent("professional/dashboard", model(

--- a/2850final project/src/main/resources/templates/professional/dashboard.html
+++ b/2850final project/src/main/resources/templates/professional/dashboard.html
@@ -61,8 +61,10 @@
                     <td th:text="${c.goalCalories}">2000</td>
                     <td>
                         <div class="progress progress--compact" role="progressbar" aria-label="Client compliance progress" th:attr="aria-valuenow=${c.compliance}" aria-valuemin="0" aria-valuemax="100">
-                            <div class="progress__fill progress__fill--cal" th:style="|width: ${c.compliance}%;|"></div>
+                            <!-- bar width uses the visual cap so a 150% client doesn't overflow the track -->
+                            <div class="progress__fill progress__fill--cal" th:style="|width: ${c.complianceVisual}%;|"></div>
                         </div>
+                        <!-- text shows the real percentage so over-eating reads as e.g. "150%" -->
                         <span class="table-pct" th:text="${c.compliance} + '%'">0%</span>
                     </td>
                     <td>


### PR DESCRIPTION
Closes #115.

## Summary
- Compliance percentage no longer capped at 100. A client at 150% of goal now reads `150%` in the table (was silently clamped to `100%`).
- Status band tightened and made symmetric:
  - `< 80%` → **Needs Attention** (under-eating)
  - `80%–100%` → **On Track**
  - `> 100%` → **Needs Attention** (over-eating)
- Inline progress-bar width uses a separate `complianceVisual` capped at 100 so the bar doesn't overflow the track when the actual percentage is over.

## Files changed
- `ProfessionalRoutes.kt` — band logic + uncapped compliance + new `complianceVisual` field.
- `professional/dashboard.html` — bar reads `complianceVisual`, text reads `compliance`.

## Per-request decision
Both flag states use the same `status-pill--warn` style. The user explicitly said both should show "Needs Attention" — the percentage in the adjacent cell distinguishes under (e.g., `57%`) from over (e.g., `150%`).

## Test plan
- [ ] Subscriber with 0 logged calories today → Compliance 0%, Status Needs Attention.
- [ ] Subscriber at 1600/2000 (80%) → On Track.
- [ ] Subscriber at 2000/2000 (100%) → On Track.
- [ ] Subscriber at 2400/2000 (120%) → table cell reads `120%`, Status Needs Attention. Progress bar fills 100% of the track (not overflowing).
- [ ] Subscriber at 1200/2000 (60%) → table reads `60%`, Status Needs Attention.