### PR TITLE
feat: recipes calories / protein / cooking-time filters (v0.6.35)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.35] - 2026-05-04 — Recipes: calories / protein / cooking-time filters (closes #117)
+
+### Added
+- Three new dropdowns on `/recipes` alongside the existing search + difficulty:
+
+| Filter | Bucket | Threshold |
+|---|---|---|
+| **Calories** (per serving) | Light / Standard / Hearty | ≤ 400 / 401–650 / > 650 kcal |
+| **Protein** (per serving) | Low / Moderate / High | < 15g / 15–25g / > 25g |
+| **Time** (prep + cook) | Quick / Standard / Slow | ≤ 20 / 21–45 / > 45 min |
+
+- Thresholds picked from common nutrition / fitness app standards: **25g** is the canonical "high protein" line (≈ 100g chicken breast), **400 kcal** is the breakfast / light-meal ceiling, **20 min** is the recognized weeknight-quick threshold.
+
+### Changed
+- `RecipeService.searchRecipes` takes three new optional `String?` params (`calories` / `protein` / `time`). Macros and total time are already computed in `summariseRow` (per-serving + prep+cook), so filtering happens in Kotlin after the row pass — no SQL changes.
+- `RecipeRoutes` reads the three new query params, passes them through to the service, and reflects them back to the template so the dropdowns retain selected state across submissions.
+- Featured-strip suppression logic widened: any active filter (search OR any of the four dropdowns) hides the strip so the page renders just the user's results. Clearing all filters brings it back.
+
+### Implementation notes
+- Three small private helpers in `RecipeService` — `matchesCalorieBucket` / `matchesProteinBucket` / `matchesTimeBucket` — each early-returns `true` when the bucket is `"all"` or blank, so unfiltered queries are zero-cost.
+- Reuses the existing `.input-select` and `.filter-bar--inline` CSS classes — no new styles needed; the filter bar wraps gracefully when the four dropdowns + search + button exceed one row.
+
+---
+
 ## [v0.6.34] - 2026-05-04 — Pro Clients: tighter compliance band, over-eating surfaces honestly (closes #115)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeRoutes.kt
@@ -13,16 +13,30 @@ import io.ktor.server.thymeleaf.*
 fun Route.recipeRoutes() {
     get("/recipes") {
         val session = call.sessions.get<UserSession>() ?: return@get call.respondRedirect("/login")
-        val query = call.request.queryParameters["q"]; val difficulty = call.request.queryParameters["difficulty"]
-        val recipes = RecipeService.searchRecipes(query, difficulty)
-        // Only show the Featured strip on the unfiltered landing — when the user
-        // is searching, hide it so the page is just their results.
-        val featured = if (query.isNullOrBlank() && (difficulty.isNullOrBlank() || difficulty == "all"))
-            RecipeService.getFeatured(3) else emptyList()
+        val query = call.request.queryParameters["q"]
+        val difficulty = call.request.queryParameters["difficulty"]
+        val calories = call.request.queryParameters["calories"]
+        val protein = call.request.queryParameters["protein"]
+        val time = call.request.queryParameters["time"]
+        val recipes = RecipeService.searchRecipes(query, difficulty, calories, protein, time)
+        // Featured strip only shows on the truly unfiltered landing — any active
+        // filter (search or any of the four dropdowns) hides it so the page is
+        // just the user's results.
+        val anyFilterActive =
+            !query.isNullOrBlank() ||
+            (!difficulty.isNullOrBlank() && difficulty != "all") ||
+            (!calories.isNullOrBlank() && calories != "all") ||
+            (!protein.isNullOrBlank() && protein != "all") ||
+            (!time.isNullOrBlank() && time != "all")
+        val featured = if (!anyFilterActive) RecipeService.getFeatured(3) else emptyList()
         val unread = MessageService.getUnreadCount(session.userId)
         call.respond(ThymeleafContent("subscriber/recipes", model(
             "session" to session, "recipes" to recipes, "featured" to featured,
-            "query" to (query ?: ""), "difficulty" to (difficulty ?: "all"),
+            "query" to (query ?: ""),
+            "difficulty" to (difficulty ?: "all"),
+            "calories" to (calories ?: "all"),
+            "protein" to (protein ?: "all"),
+            "time" to (time ?: "all"),
             "unreadMessages" to unread, "activePage" to "recipes")))
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/recipes/RecipeService.kt
@@ -84,7 +84,13 @@ object RecipeService {
      *  servings, difficulty, average rating, review count, cover image / fallback
      *  emoji + tone, and per-serving calories / protein.
      */
-    fun searchRecipes(query: String?, difficulty: String?): List<Map<String, Any?>> = transaction {
+    fun searchRecipes(
+        query: String?,
+        difficulty: String?,
+        calories: String? = null,
+        protein: String? = null,
+        time: String? = null
+    ): List<Map<String, Any?>> = transaction {
         val baseQuery = Recipes.selectAll()
         val filtered = baseQuery.let { q ->
             if (!query.isNullOrBlank()) {
@@ -94,7 +100,49 @@ object RecipeService {
             if (!difficulty.isNullOrBlank() && difficulty != "all") q.andWhere { Recipes.difficulty eq difficulty }
             q
         }
+        // Macros (calPerServing / protPerServing) and totalTime are computed in
+        // summariseRow, not stored as columns, so the calories/protein/time
+        // buckets are evaluated in Kotlin after the row pass.
         filtered.map { summariseRow(it) }
+            .filter { row -> matchesCalorieBucket(row, calories) }
+            .filter { row -> matchesProteinBucket(row, protein) }
+            .filter { row -> matchesTimeBucket(row, time) }
+    }
+
+    /** ≤ 400 / 401–650 / > 650 kcal per serving. */
+    private fun matchesCalorieBucket(row: Map<String, Any?>, bucket: String?): Boolean {
+        if (bucket.isNullOrBlank() || bucket == "all") return true
+        val cal = (row["calPerServing"] as? BigDecimal)?.toInt() ?: return true
+        return when (bucket) {
+            "light"    -> cal <= 400
+            "standard" -> cal in 401..650
+            "hearty"   -> cal > 650
+            else       -> true
+        }
+    }
+
+    /** < 15g / 15–25g / > 25g protein per serving. */
+    private fun matchesProteinBucket(row: Map<String, Any?>, bucket: String?): Boolean {
+        if (bucket.isNullOrBlank() || bucket == "all") return true
+        val prot = (row["protPerServing"] as? BigDecimal)?.toDouble() ?: return true
+        return when (bucket) {
+            "low"      -> prot < 15.0
+            "moderate" -> prot in 15.0..25.0
+            "high"     -> prot > 25.0
+            else       -> true
+        }
+    }
+
+    /** ≤ 20 / 21–45 / > 45 min total prep + cook. */
+    private fun matchesTimeBucket(row: Map<String, Any?>, bucket: String?): Boolean {
+        if (bucket.isNullOrBlank() || bucket == "all") return true
+        val total = (row["totalTime"] as? Int) ?: return true
+        return when (bucket) {
+            "quick"    -> total <= 20
+            "standard" -> total in 21..45
+            "slow"     -> total > 45
+            else       -> true
+        }
     }
 
     /**

--- a/2850final project/src/main/resources/templates/subscriber/recipes.html
+++ b/2850final project/src/main/resources/templates/subscriber/recipes.html
@@ -68,10 +68,28 @@
             <input type="search" name="q" placeholder="Search recipes by title…"
                    th:value="${query}" aria-label="Search recipes" class="filter-bar__search"/>
             <select name="difficulty" class="input-select filter-bar__select" aria-label="Filter by difficulty">
-                <option value="all" th:selected="${difficulty == 'all'}">All difficulties</option>
-                <option value="easy" th:selected="${difficulty == 'easy'}">Easy</option>
+                <option value="all"    th:selected="${difficulty == 'all'}">All difficulties</option>
+                <option value="easy"   th:selected="${difficulty == 'easy'}">Easy</option>
                 <option value="medium" th:selected="${difficulty == 'medium'}">Medium</option>
-                <option value="hard" th:selected="${difficulty == 'hard'}">Hard</option>
+                <option value="hard"   th:selected="${difficulty == 'hard'}">Hard</option>
+            </select>
+            <select name="calories" class="input-select filter-bar__select" aria-label="Filter by calories">
+                <option value="all"      th:selected="${calories == 'all'}">All calories</option>
+                <option value="light"    th:selected="${calories == 'light'}">Light · ≤ 400 kcal</option>
+                <option value="standard" th:selected="${calories == 'standard'}">Standard · 401–650 kcal</option>
+                <option value="hearty"   th:selected="${calories == 'hearty'}">Hearty · &gt; 650 kcal</option>
+            </select>
+            <select name="protein" class="input-select filter-bar__select" aria-label="Filter by protein">
+                <option value="all"      th:selected="${protein == 'all'}">All protein</option>
+                <option value="low"      th:selected="${protein == 'low'}">Low · &lt; 15 g</option>
+                <option value="moderate" th:selected="${protein == 'moderate'}">Moderate · 15–25 g</option>
+                <option value="high"     th:selected="${protein == 'high'}">High · &gt; 25 g</option>
+            </select>
+            <select name="time" class="input-select filter-bar__select" aria-label="Filter by cooking time">
+                <option value="all"      th:selected="${time == 'all'}">Any time</option>
+                <option value="quick"    th:selected="${time == 'quick'}">Quick · ≤ 20 min</option>
+                <option value="standard" th:selected="${time == 'standard'}">Standard · 21–45 min</option>
+                <option value="slow"     th:selected="${time == 'slow'}">Slow · &gt; 45 min</option>
             </select>
             <button type="submit" class="btn btn--primary">Apply</button>
         </form>


### PR DESCRIPTION
Closes #117.

## Summary
Three new dropdowns on `/recipes`:

| Filter | Bucket | Threshold |
|---|---|---|
| **Calories** | Light / Standard / Hearty | ≤ 400 / 401–650 / > 650 kcal |
| **Protein** | Low / Moderate / High | < 15g / 15–25g / > 25g |
| **Time** | Quick / Standard / Slow | ≤ 20 / 21–45 / > 45 min |

Thresholds match common nutrition / fitness app standards (25g = canonical high-protein line, 400 kcal = light-meal ceiling, 20 min = weeknight-quick).

## Files changed
- `RecipeService.searchRecipes` — three new optional params + post-filter helpers.
- `RecipeRoutes` — read params, pass through, reflect back for sticky state. Featured strip suppression widened to any active filter.
- `recipes.html` — three new `<select>` dropdowns with thresholds visible in the option labels.

## Implementation notes
- Filtering runs in Kotlin after the row pass — `calPerServing` / `protPerServing` / `totalTime` aren't stored as columns; they're computed by `summariseRow`. The three bucket helpers each early-return on `"all"` or blank so unfiltered queries are zero-cost.
- Reuses existing `.input-select` and `.filter-bar--inline` styles. The filter bar wraps gracefully when search + 4 selects + button exceed one row.

## Test plan
- [ ] `/recipes` — four dropdowns visible; defaults all "All".
- [ ] Pick `Calories: Light · ≤ 400` → only short-meal recipes show.
- [ ] Pick `Protein: High · > 25g` → only protein-heavy recipes (e.g. Grilled Chicken Salad, Salmon).
- [ ] Pick `Time: Quick · ≤ 20 min` → only quick recipes.
- [ ] Combine all four + search query — all conditions AND together.
- [ ] Reload — selected dropdowns retain their values from the URL.
- [ ] Featured strip hides as soon as any filter is non-default; reappears when all are reset.