### PR TITLE
feat: registration password complexity (upper + lower + digit) (v0.6.36)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.36] - 2026-05-04 — Registration password complexity (upper + lower + digit) (closes #119)
+
+### Added
+- New `UserService.validatePassword(password)` returns the specific reason a password is rejected — `null` on valid, otherwise one of:
+  - `Password must be at least 6 characters.`
+  - `Password must include an uppercase letter (A–Z).`
+  - `Password must include a lowercase letter (a–z).`
+  - `Password must include a number (0–9).`
+
+  Order is most-actionable-first (length before character classes) so the user fixes the simplest issue first.
+- Register tab now shows the rule inline as a `field-hint` under the password input, so users see the requirement before submission, not just after a failed attempt.
+
+### Changed
+- `POST /register` calls `validatePassword` before `UserService.register` and surfaces the specific failure reason in the existing red-banner error region. Replaces the previous generic `"Please fill all fields (password min 6 chars)"` message with three split, targeted messages (empty fields → `Please fill all fields.`, password mismatch → `Passwords do not match.`, complexity failure → specific reason).
+
+### Existing accounts (unchanged)
+- `UserService.authenticate` still verifies the BCrypt hash without re-checking strength. Users who registered before this rule can keep logging in with their original (potentially weaker) passwords. Only the registration code path enforces the new requirement.
+
+---
+
 ## [v0.6.35] - 2026-05-04 — Recipes: calories / protein / cooking-time filters (closes #117)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/auth/AuthRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/auth/AuthRoutes.kt
@@ -36,14 +36,24 @@ fun Route.authRoutes() {
         val fullName = params["fullName"] ?: ""; val email = params["email"] ?: ""
         val password = params["password"] ?: ""; val confirmPassword = params["confirmPassword"] ?: ""
         val role = params["role"] ?: "subscriber"
-        if (password != confirmPassword) { call.respond(ThymeleafContent("auth/login", model("error" to "Passwords do not match", "tab" to "register"))); return@post }
-        if (fullName.isBlank() || email.isBlank() || password.length < 6) { call.respond(ThymeleafContent("auth/login", model("error" to "Please fill all fields (password min 6 chars)", "tab" to "register"))); return@post }
+        if (fullName.isBlank() || email.isBlank()) {
+            call.respond(ThymeleafContent("auth/login", model("error" to "Please fill all fields.", "tab" to "register"))); return@post
+        }
+        if (password != confirmPassword) {
+            call.respond(ThymeleafContent("auth/login", model("error" to "Passwords do not match.", "tab" to "register"))); return@post
+        }
+        // Password complexity gate (v0.6.36). Returns the specific reason so the
+        // user knows which rule to satisfy.
+        val passwordError = UserService.validatePassword(password)
+        if (passwordError != null) {
+            call.respond(ThymeleafContent("auth/login", model("error" to passwordError, "tab" to "register"))); return@post
+        }
         val userId = UserService.register(fullName, email, password, role)
         if (userId != null) {
             call.sessions.set(UserSession(userId, fullName, email, role))
             if (role == "professional") call.respondRedirect("/pro/dashboard") else call.respondRedirect("/dashboard")
         } else {
-            call.respond(ThymeleafContent("auth/login", model("error" to "Email already registered", "tab" to "register")))
+            call.respond(ThymeleafContent("auth/login", model("error" to "Email already registered.", "tab" to "register")))
         }
     }
 

--- a/2850final project/src/main/kotlin/com/goodfood/auth/UserService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/auth/UserService.kt
@@ -40,6 +40,24 @@ object UserService {
      *  and which routes the user can reach.
      * @return the new user's auto-generated `id`, or `null` when the email already exists.
      */
+    /**
+     * v0.6.36 — password-complexity gate for new registrations. Returns the
+     * specific reason a password is rejected, or `null` when it passes. Order
+     * matters: surface the most-actionable failure first (length before
+     * character classes).
+     *
+     * Existing accounts whose hashes pre-date this rule are unaffected —
+     * [authenticate] only verifies the BCrypt hash, not strength, so old
+     * passwords still log in.
+     */
+    fun validatePassword(password: String): String? = when {
+        password.length < 6 -> "Password must be at least 6 characters."
+        !password.any { it.isUpperCase() } -> "Password must include an uppercase letter (A–Z)."
+        !password.any { it.isLowerCase() } -> "Password must include a lowercase letter (a–z)."
+        !password.any { it.isDigit() } -> "Password must include a number (0–9)."
+        else -> null
+    }
+
     fun register(fullName: String, email: String, password: String, role: String): Int? = transaction {
         if (Users.selectAll().where { Users.email eq email }.count() > 0) return@transaction null
         val hash = BCrypt.withDefaults().hashToString(12, password.toCharArray())

--- a/2850final project/src/main/resources/templates/auth/login.html
+++ b/2850final project/src/main/resources/templates/auth/login.html
@@ -54,7 +54,11 @@
                 </label>
                 <label class="field">
                     <span class="field__label">Password</span>
-                    <input type="password" name="password" required minlength="6" autocomplete="new-password"/>
+                    <input type="password" name="password" required minlength="6" autocomplete="new-password"
+                           aria-describedby="register-password-hint"/>
+                    <p id="register-password-hint" class="field-hint">
+                        Must include an uppercase letter, a lowercase letter, and a number. Minimum 6 characters.
+                    </p>
                 </label>
                 <label class="field">
                     <span class="field__label">Confirm password</span>


### PR DESCRIPTION
Closes #119.

## Summary
New registrations must include uppercase + lowercase + digit; min length stays at 6. Existing accounts unchanged.

## Files changed
- `UserService.kt` — new `validatePassword(password): String?` (null = valid; otherwise specific reason).
- `AuthRoutes.kt` — `POST /register` calls the validator and returns its message in the existing error banner. Generic "min 6 chars" replaced by three targeted messages (empty fields / password mismatch / complexity reason).
- `auth/login.html` — Register tab shows the rule inline as a `field-hint` under the password input.

## Specific error messages

| Failure | Banner copy |
|---|---|
| `< 6` chars | `Password must be at least 6 characters.` |
| missing uppercase | `Password must include an uppercase letter (A–Z).` |
| missing lowercase | `Password must include a lowercase letter (a–z).` |
| missing digit | `Password must include a number (0–9).` |

Ordered most-actionable-first so the simplest fix surfaces first.

## Existing accounts
`authenticate()` only verifies the BCrypt hash — never re-checks strength. Users who registered before this rule can keep logging in with their original passwords. Only the registration code path enforces the new requirement.

## Test plan
- [ ] Register with `abc` → "Password must be at least 6 characters."
- [ ] Register with `abcdef` → "Password must include an uppercase letter (A–Z)."
- [ ] Register with `ABCDEF` → "Password must include a lowercase letter (a–z)."
- [ ] Register with `Abcdef` → "Password must include a number (0–9)."
- [ ] Register with `Abcdef1` → succeeds, redirected to dashboard.
- [ ] Existing account (registered before this PR) logs in with their old `secret` password just fine.
- [ ] Register tab shows the inline hint right under the password input.