### PR TITLE
fix: messages dropped on send + cross-device live polling (v0.6.37)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.37] - 2026-05-05 — Messages: fix dropped sends (multipart bug) + cross-device live polling (closes #121)
+
+### Fixed
+- **Messages were silently disappearing**. v0.6.26 introduced an AJAX submit that built its body via `new FormData(compose)` and let `fetch` default to `multipart/form-data`. The server route does `call.receiveParameters()`, which in Ktor only parses `application/x-www-form-urlencoded` — multipart bodies came back as empty `Parameters`, so `params["message"]` was `null`, the `isNotBlank()` guard skipped the insert, and **the message never reached the database**. Sender saw their optimistic bubble; on refresh it vanished, and no other device ever saw it.
+  - Fix: switch the AJAX body to `URLSearchParams(new FormData(compose))` and set `Content-Type: application/x-www-form-urlencoded; charset=UTF-8` explicitly. Server route stays unchanged.
+
+### Added — cross-device real-time
+- **Polling endpoint** `GET /api/messages/{partnerId}/since/{lastId}` returns every message in the thread newer than `lastId` (chronological), and as a side-effect marks any newly-arrived message FROM the partner as read — same behaviour as the full-page `getConversation`.
+- **`MessageService.getConversationSince(userId, partnerId, lastId)`** powers the new endpoint.
+- **Front-end polling loop** in `initChatPage` — every 4 seconds while a chat is open:
+  - Reads the highest `data-message-id` currently rendered.
+  - Fetches `/api/messages/{partnerId}/since/{lastId}`.
+  - For each returned message: if a `data-message-id` already exists, skip (dedup). If it's a `mine` message and a `.bubble--mine:not([data-message-id])` with matching text exists, reconcile (set the id, drop `.bubble--pending`). Otherwise append a fresh bubble to the last `.chat-day` group.
+  - If the user was within 60px of the bottom before the append, auto-scroll to follow new messages. If they were scrolled up reading older messages, leave them in place.
+- **Battery-friendly**: polling pauses while the tab is hidden (`visibilitychange`), and fires one immediate poll on tab focus so a user returning from a background tab sees fresh messages right away.
+
+### Schema-side bits
+- Each `.bubble` carries `data-message-id="N"` (template change, both subscriber + professional templates) so polling dedup works.
+- `.chat-scroll` carries `data-partner-id` so JS knows which conversation to poll.
+
+### Result
+Two devices logged in as different users (or even the same user on two browsers) on `/messages/{partnerId}` now see each other's messages within 4 seconds of send, no manual refresh, no Telegram-style WebSocket complexity.
+
+---
+
 ## [v0.6.36] - 2026-05-04 — Registration password complexity (upper + lower + digit) (closes #119)
 
 ### Added

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
@@ -83,4 +83,19 @@ fun Route.messageRoutes() {
         if (message.isNotBlank()) MessageService.sendMessage(session.userId, partnerId, message)
         call.respondRedirect("/messages/$partnerId")
     }
+
+    /**
+     * Polling endpoint backbone for cross-device real-time updates (v0.6.37).
+     * Front-end calls this every few seconds while a chat is open; returns
+     * every message in the thread whose id is greater than [lastId] in
+     * chronological order. Side-effect: marks newly-arrived messages from the
+     * partner as read.
+     */
+    get("/api/messages/{partnerId}/since/{lastId}") {
+        val session = call.sessions.get<UserSession>() ?: return@get call.respond(io.ktor.http.HttpStatusCode.Unauthorized)
+        val partnerId = call.parameters["partnerId"]?.toIntOrNull()
+            ?: return@get call.respond(io.ktor.http.HttpStatusCode.BadRequest)
+        val lastId = call.parameters["lastId"]?.toIntOrNull() ?: 0
+        call.respond(MessageService.getConversationSince(session.userId, partnerId, lastId))
+    }
 }

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageService.kt
@@ -90,6 +90,37 @@ object MessageService {
     }
 
     /**
+     * Polling endpoint backbone (v0.6.37). Returns every message in the
+     * [userId]↔[partnerId] thread whose `id` is greater than [lastId], in
+     * chronological order. Caller (JS) tracks the highest id it has rendered
+     * and asks for newer ones every few seconds.
+     *
+     * Marks any newly-arrived message FROM the partner as read, same as
+     * [getConversation] does on full page load.
+     */
+    fun getConversationSince(userId: Int, partnerId: Int, lastId: Int): List<Map<String, Any>> = transaction {
+        AdviceMessages.update({
+            (AdviceMessages.senderId eq partnerId) and (AdviceMessages.receiverId eq userId) and (AdviceMessages.isRead eq false)
+        }) { it[isRead] = true }
+        AdviceMessages.selectAll().where {
+            (
+                ((AdviceMessages.senderId eq userId) and (AdviceMessages.receiverId eq partnerId)) or
+                ((AdviceMessages.senderId eq partnerId) and (AdviceMessages.receiverId eq userId))
+            ) and (AdviceMessages.id greater lastId)
+        }.orderBy(AdviceMessages.sentAt).map { row ->
+            val ts = row[AdviceMessages.sentAt]
+            mapOf(
+                "id" to row[AdviceMessages.id],
+                "senderId" to row[AdviceMessages.senderId],
+                "message" to row[AdviceMessages.message],
+                "sentAt" to ts.fmtChatTime(),
+                "sentTime" to ts.format(DateTimeFormatter.ofPattern("HH:mm")),
+                "isMine" to (row[AdviceMessages.senderId] == userId)
+            )
+        }
+    }
+
+    /**
      * "Directory" — every user of the opposite role that [userId] has *not*
      * yet exchanged messages with. Powers the new-conversation list at the
      * bottom of `/messages`. Subscribers see professionals, professionals see

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -297,7 +297,8 @@
     }
 
     /* ---- Chat: scroll-to-bottom on load, auto-resize composer, send-on-Enter,
-           optimistic AJAX submit, conversation list filter. Telegram-style. ---- */
+           optimistic AJAX submit, polling for cross-device live updates,
+           conversation list filter. Telegram-style. ---- */
     function initChatPage() {
         var scrollEl = document.querySelector(".js-chat-scroll");
         var compose  = document.querySelector(".js-chat-compose");
@@ -306,9 +307,7 @@
         var filterEl = document.querySelector(".js-conv-filter");
 
         // 1. Scroll the message log to the bottom on first paint so the latest
-        //    message is visible without manual scrolling. Use scrollTop directly
-        //    (instant) instead of smooth — smooth scroll runs after paint and
-        //    flickers from top.
+        //    message is visible without manual scrolling.
         if (scrollEl) {
             scrollEl.scrollTop = scrollEl.scrollHeight;
         }
@@ -330,14 +329,14 @@
                     if (!sendBtn.disabled) compose.requestSubmit();
                 }
             });
-            // Focus when the page lands so a returning user can just type.
             input.focus();
             syncSendDisabled();
 
-            // 3. Optimistic AJAX submit: append the bubble locally, fire-and-forget
-            //    the POST. The route still 302-redirects; we ignore the body and
-            //    rely on the next navigation (or a manual refresh) to reconcile
-            //    server state. Keeps the UI feeling instant.
+            // 3. Optimistic AJAX submit. v0.6.37 fix: Ktor's
+            //    call.receiveParameters() only parses application/x-www-form-urlencoded.
+            //    Sending FormData here would default to multipart/form-data and the
+            //    server would silently see message="" — messages dropped, never saved.
+            //    URLSearchParams(FormData) gives us urlencoded explicitly.
             compose.addEventListener("submit", function (e) {
                 if (sendBtn.disabled) { e.preventDefault(); return; }
                 var text = input.value.trim();
@@ -348,11 +347,16 @@
                 autosize();
                 syncSendDisabled();
 
-                var fd = new FormData(compose);
-                fetch(compose.action, { method: "POST", body: fd, redirect: "manual" })
+                var body = new URLSearchParams(new FormData(compose));
+                fetch(compose.action, {
+                    method: "POST",
+                    body: body,
+                    headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
+                    redirect: "manual"
+                })
                     .then(function () {
-                        // Mark the optimistic bubble as confirmed (drops the
-                        // "sending…" annotation); leave it in place.
+                        // Drop the "sending…" annotation. The next poll will
+                        // attach the real data-message-id.
                         var pending = scrollEl.querySelector(".bubble--pending");
                         if (pending) pending.classList.remove("bubble--pending");
                     })
@@ -366,8 +370,16 @@
             });
         }
 
-        // 4. Conversation filter: case-insensitive substring match on
-        //    [data-name]; toggles .is-hidden on each row, shows an empty hint.
+        // 4. Polling — cross-device live updates. Every 4s, ask the server for
+        //    every message in this thread newer than the highest id we've
+        //    rendered. Append new bubbles. Reconcile pending bubbles whose
+        //    server-side counterpart has just landed.
+        if (scrollEl && scrollEl.dataset.partnerId) {
+            startChatPolling(scrollEl);
+        }
+
+        // 5. Conversation filter (substring match on data-name across both the
+        //    existing-conversations list and the directory list).
         if (filterEl) {
             var rows = document.querySelectorAll(".conv-list__row");
             var emptyHint = document.querySelector(".chat-search__empty");
@@ -383,6 +395,103 @@
                 if (emptyHint) emptyHint.hidden = anyVisible || rows.length === 0;
             });
         }
+    }
+
+    /* Polling loop. ~4s interval. Stops when the tab is hidden, resumes on
+       focus to avoid burning battery in background tabs. */
+    function startChatPolling(scrollEl) {
+        var partnerId = scrollEl.dataset.partnerId;
+        if (!partnerId) return;
+
+        function highestRenderedId() {
+            var ids = Array.prototype.map.call(
+                scrollEl.querySelectorAll(".bubble[data-message-id]"),
+                function (b) { return parseInt(b.getAttribute("data-message-id"), 10) || 0; }
+            );
+            return ids.length ? Math.max.apply(null, ids) : 0;
+        }
+
+        function isAtBottom() {
+            // Within 60px of the bottom = "user is reading the latest", auto-scroll on append.
+            return (scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight) < 60;
+        }
+
+        function poll() {
+            if (document.hidden) return;
+            var lastId = highestRenderedId();
+            fetch("/api/messages/" + partnerId + "/since/" + lastId, { credentials: "same-origin" })
+                .then(function (r) { return r.ok ? r.json() : []; })
+                .then(function (messages) {
+                    if (!Array.isArray(messages) || !messages.length) return;
+                    var stickToBottom = isAtBottom();
+                    messages.forEach(function (m) { reconcileOrAppend(scrollEl, m); });
+                    if (stickToBottom) scrollEl.scrollTop = scrollEl.scrollHeight;
+                })
+                .catch(function () { /* swallow — next tick will retry */ });
+        }
+
+        var POLL_MS = 4000;
+        var timer = setInterval(poll, POLL_MS);
+        // First poll fires soon after page load so messages sent on the OTHER
+        // device just before this one rendered get caught quickly.
+        setTimeout(poll, 1500);
+
+        // Pause polling while the tab is hidden; one immediate poll on focus.
+        document.addEventListener("visibilitychange", function () {
+            if (!document.hidden) poll();
+        });
+
+        // No explicit cleanup — page navigation discards the timer.
+        return timer;
+    }
+
+    /* Either reconcile a pending optimistic bubble (mine, same text, no id yet)
+       with the freshly-arrived server record, or append a new bubble. */
+    function reconcileOrAppend(scrollEl, m) {
+        // Already rendered — skip
+        if (scrollEl.querySelector('[data-message-id="' + m.id + '"]')) return;
+
+        if (m.isMine) {
+            var pendingMatch = null;
+            var candidates = scrollEl.querySelectorAll(".bubble--mine:not([data-message-id])");
+            for (var i = 0; i < candidates.length; i++) {
+                var t = candidates[i].querySelector(".bubble__text");
+                if (t && t.textContent === m.message) { pendingMatch = candidates[i]; break; }
+            }
+            if (pendingMatch) {
+                pendingMatch.setAttribute("data-message-id", String(m.id));
+                pendingMatch.classList.remove("bubble--pending");
+                return;
+            }
+        }
+
+        // Fresh bubble — create + append
+        var lastGroup = scrollEl.querySelector(".chat-day:last-of-type");
+        if (!lastGroup) {
+            var hint = scrollEl.querySelector(".empty-hint");
+            if (hint) hint.remove();
+            lastGroup = document.createElement("div");
+            lastGroup.className = "chat-day";
+            var sep = document.createElement("div");
+            sep.className = "chat-day__sep";
+            var sepInner = document.createElement("span");
+            sepInner.textContent = "Today";
+            sep.appendChild(sepInner);
+            lastGroup.appendChild(sep);
+            scrollEl.appendChild(lastGroup);
+        }
+        var bubble = document.createElement("div");
+        bubble.className = m.isMine ? "bubble bubble--mine" : "bubble bubble--theirs";
+        bubble.setAttribute("data-message-id", String(m.id));
+        var p = document.createElement("p");
+        p.className = "bubble__text";
+        p.textContent = m.message;
+        bubble.appendChild(p);
+        var time = document.createElement("time");
+        time.className = "bubble__time";
+        time.textContent = m.sentTime || "";
+        bubble.appendChild(time);
+        lastGroup.appendChild(bubble);
     }
 
     function appendOptimisticBubble(scrollEl, text) {

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -97,14 +97,17 @@
                 <div class="chat-main__head chat-main__head--empty" th:if="${activePartnerId == null}">
                     <p class="empty-hint">Select a client conversation.</p>
                 </div>
-                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
+                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite"
+                     th:if="${activePartnerId != null}"
+                     th:attr="data-partner-id=${activePartnerId}">
                     <p class="empty-hint" th:if="${conversationGroups == null or conversationGroups.isEmpty()}">
                         No messages yet.
                     </p>
                     <div th:each="day : ${conversationGroups}" class="chat-day">
                         <div class="chat-day__sep"><span th:text="${day.label}">Today</span></div>
                         <div th:each="m : ${day.messages}"
-                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
+                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'"
+                             th:attr="data-message-id=${m.id}">
                             <p class="bubble__text" th:text="${m.message}">Text</p>
                             <time class="bubble__time" th:text="${m.sentTime}">14:32</time>
                         </div>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -101,14 +101,17 @@
                 <div class="chat-main__head chat-main__head--empty" th:if="${activePartnerId == null}">
                     <p class="empty-hint">Select a conversation to read messages.</p>
                 </div>
-                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite" th:if="${activePartnerId != null}">
+                <div class="chat-scroll js-chat-scroll" role="log" aria-live="polite"
+                     th:if="${activePartnerId != null}"
+                     th:attr="data-partner-id=${activePartnerId}">
                     <p class="empty-hint" th:if="${conversationGroups == null or conversationGroups.isEmpty()}">
                         No messages yet — say hello!
                     </p>
                     <div th:each="day : ${conversationGroups}" class="chat-day">
                         <div class="chat-day__sep"><span th:text="${day.label}">Today</span></div>
                         <div th:each="m : ${day.messages}"
-                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'">
+                             th:class="${m.isMine} ? 'bubble bubble--mine' : 'bubble bubble--theirs'"
+                             th:attr="data-message-id=${m.id}">
                             <p class="bubble__text" th:text="${m.message}">Text</p>
                             <time class="bubble__time" th:text="${m.sentTime}">14:32</time>
                         </div>


### PR DESCRIPTION
Closes #121.

## Two issues, one PR

### 1. Bug — messages were silently disappearing

`v0.6.26` rewrote the chat composer to AJAX-submit. It built the body with `new FormData(compose)`, which makes `fetch` default to `multipart/form-data`. But the server uses:

```kotlin
val message = call.receiveParameters()["message"] ?: ""
if (message.isNotBlank()) MessageService.sendMessage(...)
```

`call.receiveParameters()` only parses `application/x-www-form-urlencoded` — for multipart bodies it returns an empty `Parameters`, so `message` was `""`, the guard skipped the insert, and the message never reached the database. Sender saw their optimistic bubble (because the JS appends locally before the network call); on refresh it vanished, and no other device ever saw it.

**Fix**: build the body with `URLSearchParams(new FormData(compose))` and set `Content-Type: application/x-www-form-urlencoded; charset=UTF-8` explicitly. Server route stays unchanged. Messages persist.

### 2. Feature — cross-device live updates via polling

Even after the bug fix, the receiver's chat is rendered server-side at page-load and never updates without a refresh. User explicitly wants real-time across two or more devices.

**Implementation**:
- `MessageService.getConversationSince(userId, partnerId, lastId)` — returns messages newer than `lastId`, marks partner messages read.
- `GET /api/messages/{partnerId}/since/{lastId}` — JSON endpoint backing the poll.
- `initChatPage` polls every 4s. Highest rendered `data-message-id` becomes the next `lastId`. New messages get reconciled (pending bubble + matching mine + same text → set the id, drop `.bubble--pending`) or appended fresh.
- Polling pauses on `document.hidden`, fires once on tab focus. Auto-scroll follows new messages only if the user was within 60px of the bottom (so they can scroll up to read history without getting yanked).

### Templates
- `.bubble` gets `data-message-id="N"` (subscriber + professional templates).
- `.chat-scroll` gets `data-partner-id` so the JS knows which conversation to poll.

## Test plan
- [ ] Open `/messages/{partnerId}` on Browser A logged in as the user.
- [ ] Open `/messages/{userId}` on Browser B logged in as the partner.
- [ ] Type a message on A and hit Enter — it appears immediately on A. Within 4s it appears on B without B refreshing.
- [ ] Send back from B — within 4s A sees it.
- [ ] Send 5 messages quickly from A — all 5 reach the DB (verify with full refresh: they're still there). On B, the 5 land within one poll cycle.
- [ ] Refresh A — every sent message persists (proves the multipart bug is fixed).
- [ ] Open DevTools Network on A — confirm POST `/messages/{partnerId}` body is `Content-Type: application/x-www-form-urlencoded` (not multipart).
- [ ] Hide a tab for 2 minutes, come back — one fresh poll fires immediately on focus.