### PR TITLE
copy: tighten landing page subtitles (v0.6.38)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.38] - 2026-05-05 — Landing page: tighten the four subtitle blocks (closes #123)
+
+### Changed
+- `landing.html` — four subtitle paragraphs replaced per copy direction:
+  - **Hero**: `Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one.` *(dropped: "Built for people who'd rather know than guess.")*
+  - **Track**: `Search verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring.` *(dropped: leading "200+", trailing "No streaks, no shaming…" sentence)*
+  - **Cook**: `Home-cooking recipes with macros pre-calculated. Save the ones that fit your week.` *(dropped: leading "180+", trailing "Rate them after dinner…" sentence)*
+  - **Coach**: `Direct-message a registered practitioner about a goal, a binge, or a Friday night. Tailored advice whenever you need it.` *(replaced second sentence)*
+
+---
+
 ## [v0.6.37] - 2026-05-05 — Messages: fix dropped sends (multipart bug) + cross-device live polling (closes #121)
 
 ### Fixed

--- a/2850final project/src/main/resources/templates/landing.html
+++ b/2850final project/src/main/resources/templates/landing.html
@@ -57,7 +57,7 @@
                 <span class="landing-hero__title-accent">intention.</span>
             </h1>
             <p class="landing-hero__sub" data-reveal style="--i:2">
-                Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one. Built for people who'd rather know than guess.
+                Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one.
             </p>
             <div class="landing-hero__ctas" data-reveal style="--i:3">
                 <th:block th:if="${session == null}">
@@ -112,7 +112,7 @@
             <p class="landing-section__eyebrow">Track.</p>
             <h2 class="landing-section__title">Every bite,<br/>in 6 seconds.</h2>
             <p class="landing-section__sub">
-                Search 200+ verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring. No streaks, no shaming — just the number, when you want it.
+                Search verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring.
             </p>
         </div>
         <div class="landing-section__visual" aria-hidden="true">
@@ -136,7 +136,7 @@
             <p class="landing-section__eyebrow">Cook.</p>
             <h2 class="landing-section__title">Recipes that travel<br/>with you.</h2>
             <p class="landing-section__sub">
-                180+ home-cooking recipes with macros pre-calculated. Save the ones that fit your week. Rate them after dinner — the ones you keep cooking float to the top.
+                Home-cooking recipes with macros pre-calculated. Save the ones that fit your week.
             </p>
         </div>
         <div class="landing-section__visual" aria-hidden="true">
@@ -169,7 +169,7 @@
             <p class="landing-section__eyebrow">Coach.</p>
             <h2 class="landing-section__title">A nutritionist<br/>on call.</h2>
             <p class="landing-section__sub">
-                Direct-message a registered practitioner about a goal, a binge, or a Friday night. They reply in their actual voice — not a chatbot, not a canned reply, not a 24-hour wait.
+                Direct-message a registered practitioner about a goal, a binge, or a Friday night. Tailored advice whenever you need it.
             </p>
         </div>
         <div class="landing-section__visual" aria-hidden="true">


### PR DESCRIPTION
Closes #123.

Four subtitle paragraphs replaced per copy direction:

| Section | New copy |
|---|---|
| Hero | Track what you eat, plan what you cook, and stay close to a registered nutritionist when you want one. |
| Track | Search verified foods, log breakfast on the bus, and watch your macros land on a single calorie ring. |
| Cook | Home-cooking recipes with macros pre-calculated. Save the ones that fit your week. |
| Coach | Direct-message a registered practitioner about a goal, a binge, or a Friday night. Tailored advice whenever you need it. |

## Test plan
- [ ] Visit `/` — four subtitle blocks read exactly as above. No `200+` / `180+` / "Built for people who'd rather know than guess." remains.