### PR TITLE
fix: harden chat AJAX, surface send failures (v0.6.39)

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [v0.6.39] - 2026-05-05 — Messages send: harden AJAX, surface failures (closes #125)
+
+### Fixed
+- **v0.6.37 still left silent failure paths.** The AJAX send used `redirect: "manual"`, which makes the response opaque — fetch resolved the promise even when the server rejected the request. The optimistic bubble dropped its "sending…" class regardless, so the user saw a phantom "sent" while the row was never inserted. After refresh: nothing.
+- Server now branches on the `Accept` header. AJAX clients send `Accept: application/json` and get back `{ok: true|false}` so success/failure is unambiguous. Native `<form method=post>` (no JS fallback) keeps the previous 302 redirect behaviour.
+- Client switched to an explicit urlencoded string body (`"message=" + encodeURIComponent(msgValue)`) — sidesteps any `URLSearchParams(FormData)` quirks. Also drops `redirect: "manual"`, adds explicit `credentials: "same-origin"`, and checks `response.ok`.
+- Three `console.info / warn / error` lines now log every send attempt, server-rejected ack, and network failure — DevTools console makes the path visible instead of silently flipping bubbles to `--failed`.
+
+### What this means for testing
+Open DevTools → Network when sending a message. You should see:
+- `POST /messages/{partnerId}` → `200 OK` with body `{"ok": true}`.
+- Console line `[chat] sent ok`.
+- A poll within 4s picking up the new message.
+
+If you see `[chat] send failed: ...` or a non-200 response, the actual error is now in the console, not buried.
+
+---
+
 ## [v0.6.38] - 2026-05-05 — Landing page: tighten the four subtitle blocks (closes #123)
 
 ### Changed

--- a/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
+++ b/2850final project/src/main/kotlin/com/goodfood/messages/MessageRoutes.kt
@@ -80,8 +80,17 @@ fun Route.messageRoutes() {
         val session = call.sessions.get<UserSession>() ?: return@post call.respondRedirect("/login")
         val partnerId = call.parameters["partnerId"]?.toIntOrNull() ?: return@post call.respondRedirect("/messages")
         val message = call.receiveParameters()["message"] ?: ""
-        if (message.isNotBlank()) MessageService.sendMessage(session.userId, partnerId, message)
-        call.respondRedirect("/messages/$partnerId")
+        // v0.6.39 — AJAX clients send `Accept: application/json` so we can
+        // signal success/failure cleanly instead of relying on opaque 302s.
+        // Native form submit (no JS) still falls back to the redirect path.
+        val wantsJson = call.request.headers["Accept"]?.contains("application/json", ignoreCase = true) == true
+        val ok = message.isNotBlank()
+        if (ok) MessageService.sendMessage(session.userId, partnerId, message)
+        if (wantsJson) {
+            call.respond(mapOf("ok" to ok))
+        } else {
+            call.respondRedirect("/messages/$partnerId")
+        }
     }
 
     /**

--- a/2850final project/src/main/resources/static/js/app.js
+++ b/2850final project/src/main/resources/static/js/app.js
@@ -347,20 +347,47 @@
                 autosize();
                 syncSendDisabled();
 
-                var body = new URLSearchParams(new FormData(compose));
+                // v0.6.39 — bulletproof AJAX send.
+                //  • body: explicit URLSearchParams string (works around any
+                //    browser quirks with FormData → urlencoded conversion).
+                //  • Accept: application/json so the server returns
+                //    {ok: true|false} instead of an opaque 302 redirect.
+                //  • credentials: "same-origin" makes the session cookie
+                //    explicit (defaults are usually fine; this is belt+braces).
+                //  • response.ok check + console logging so failures are
+                //    visible in DevTools instead of silently flipping the
+                //    bubble to failed.
+                var msgValue = (compose.querySelector("[name=message]") || {}).value || text;
+                var bodyStr = "message=" + encodeURIComponent(msgValue);
+                console.info("[chat] sending to", compose.action, "len=", msgValue.length);
                 fetch(compose.action, {
                     method: "POST",
-                    body: body,
-                    headers: { "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8" },
-                    redirect: "manual"
+                    body: bodyStr,
+                    headers: {
+                        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                        "Accept": "application/json"
+                    },
+                    credentials: "same-origin"
                 })
-                    .then(function () {
-                        // Drop the "sending…" annotation. The next poll will
-                        // attach the real data-message-id.
-                        var pending = scrollEl.querySelector(".bubble--pending");
-                        if (pending) pending.classList.remove("bubble--pending");
+                    .then(function (r) {
+                        if (!r.ok) throw new Error("HTTP " + r.status);
+                        return r.json().catch(function () { return { ok: true }; });
                     })
-                    .catch(function () {
+                    .then(function (result) {
+                        var pending = scrollEl.querySelector(".bubble--pending");
+                        if (result && result.ok === false) {
+                            console.warn("[chat] server rejected message (empty/blocked)");
+                            if (pending) {
+                                pending.classList.remove("bubble--pending");
+                                pending.classList.add("bubble--failed");
+                            }
+                        } else {
+                            console.info("[chat] sent ok");
+                            if (pending) pending.classList.remove("bubble--pending");
+                        }
+                    })
+                    .catch(function (err) {
+                        console.error("[chat] send failed:", err);
                         var pending = scrollEl.querySelector(".bubble--pending");
                         if (pending) {
                             pending.classList.remove("bubble--pending");


### PR DESCRIPTION
Closes #125.

## Why this PR
v0.6.37's URLSearchParams body fix was correct but didn't go far enough — `redirect: "manual"` made every fetch resolve as success regardless of what the server actually did, so failures stayed invisible and bubbles silently lost their `--pending` state even when the row was never inserted. User reports messages still vanishing after refresh.

## Hardening

### Server
`POST /messages/{partnerId}` now branches on `Accept`:
- Has `application/json` → respond `{ok: true|false}`.
- Otherwise → existing 302 redirect (native form fallback).

### Client
- Body: explicit `"message=" + encodeURIComponent(value)` string. No more `URLSearchParams(FormData)` indirection.
- Headers: `Content-Type: application/x-www-form-urlencoded; charset=UTF-8` + `Accept: application/json`.
- `credentials: "same-origin"` belt-and-braces for the session cookie.
- Drop `redirect: "manual"`. Check `response.ok`. Throw on non-OK so the catch path runs.
- `console.info` / `console.warn` / `console.error` cover send-attempt / server-rejected / network-failure. DevTools console makes the failure mode visible.

## Debugging on the live site
Open DevTools → Network when sending. You should see:
- `POST /messages/<partnerId>` → `200 OK`, body `{"ok": true}`.
- Console: `[chat] sending to /messages/<partnerId> len=<N>` then `[chat] sent ok`.
- A `GET /api/messages/<partnerId>/since/<lastId>` poll within 4 seconds picks up the new id.

If any of those don't fire, the failure mode is now in the console rather than silently swallowed.

## Test plan
- [ ] Two browsers, two roles, exchange messages — both directions work.
- [ ] DevTools Network confirms POST returns `{"ok": true}` and Content-Type is `application/x-www-form-urlencoded`.
- [ ] Console shows `[chat] sent ok` on each send.
- [ ] Refresh — every sent message is still in the thread (proves persistence).
- [ ] Disable JS — native form submit still works (server returns 302, page reloads with the new message).
- [ ] Send something on Browser A — Browser B picks it up within 4s via the poll endpoint.