### PR TITLE
mobile polish

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -3,6 +3,10 @@
 Format tightened on 2026-05-05 to short Keep-a-Changelog style. Earlier
 verbose entries are in git history (`git log -p CHANGELOG.md`).
 
+## [0.6.42] - 2026-05-05
+### Fixed
+- Mobile polish: stack header rows, full-width filter selects, tighter paddings, larger tap targets. (#134)
+
 ## [0.6.41] - 2026-05-05
 ### Added
 - 14 more recipes; total now 23. (#130)

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -3837,6 +3837,81 @@ input::placeholder, textarea::placeholder {
     .macro-row { grid-template-columns: 56px 1fr 100px; gap: 10px; }
 }
 
+/* ============================================================
+   Mobile polish — phone-width fixes (≤600 / ≤420). Stacks header
+   rows that compete for space, makes filter dropdowns full-width,
+   tightens summary-strip + action-cluster padding, bumps button tap
+   targets, and re-tunes the food-picker grid to fit 3 cards on a
+   360 px screen.
+   ============================================================ */
+@media (max-width: 600px) {
+    /* Page header — heading stacks above date-nav / actions */
+    .page-header--row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .date-nav { gap: 6px; }
+    .date-nav .btn {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+
+    /* Recipe filter bar — every control becomes full-width */
+    .filter-bar--inline { gap: 8px; }
+    .filter-bar__search,
+    .filter-bar__select {
+        flex: 1 1 100%;
+        min-width: 0;
+    }
+    .filter-bar .btn { width: 100%; }
+
+    /* Pro client-detail action cluster — Open chat full-width above date nav */
+    .client-detail__actions { width: 100%; }
+    .client-detail__actions > a.btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    /* Summary strip — tighter spacing between metrics */
+    .summary-strip {
+        gap: 12px 20px;
+        padding: 14px 18px;
+    }
+
+    /* Pro client table — tighter cell padding so more cols fit before scroll */
+    .data-table th, .data-table td {
+        padding: 10px 12px;
+        font-size: var(--text-sm);
+    }
+
+    /* Food picker — 100 px floor lets 3 cards fit on a 360 px viewport */
+    .food-picker__grid {
+        grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+        max-height: 280px;
+    }
+
+    /* Bump primary tap targets toward the 44 px Apple HIG floor */
+    .btn { padding: 12px 22px; }
+    .btn--small { padding: 9px 16px; }
+
+    /* Sticky chat header — slimmer when avatar + status crowd the row */
+    .chat-main__head { padding: 12px 16px; }
+    .chat-main__title { font-size: var(--text-sm); }
+}
+
+@media (max-width: 420px) {
+    /* Tighter still — for 360 px Android phones */
+    .main { padding: 70px 12px 24px; }
+    .card { padding: 22px 18px; }
+    .dashboard-tonight__grid { grid-template-columns: 1fr; }
+
+    /* Goals form: macros already stack to 1 col below 420 (existing rule) */
+
+    /* Modal — full-bleed-ish on the smallest phones */
+    .modal { padding: 12px; }
+    .modal__panel { padding: 20px 18px; }
+}
+
 @media print {
     .sidebar, .menu-toggle, .toast-region, .modal { display: none !important; }
     .auth-body::before, .auth-body::after { display: none !important; }


### PR DESCRIPTION
Closes #133.

Stacks competing header rows, makes recipe-filter selects full-width, tightens summary-strip / action paddings, bumps button tap targets toward 44 px, re-tunes food picker to fit 3 cards on a 360 px screen.