### PR TITLE
fix sidebar blur on iOS

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -3,6 +3,10 @@
 Format tightened on 2026-05-05 to short Keep-a-Changelog style. Earlier
 verbose entries are in git history (`git log -p CHANGELOG.md`).
 
+## [0.6.43] - 2026-05-06
+### Fixed
+- iOS Safari rendered the mobile sidebar text blurry when the drawer opened. (#136)
+
 ## [0.6.42] - 2026-05-05
 ### Fixed
 - Mobile polish: stack header rows, full-width filter selects, tighter paddings, larger tap targets. (#134)

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -3778,6 +3778,10 @@ input::placeholder, textarea::placeholder {
         width: 280px;
         z-index: 150;
         transform: translateX(-100%);
+        /* will-change forces the drawer onto its own GPU layer so iOS Safari
+           doesn't co-rasterise it with the page's backdrop-filter cards
+           (which made the sidebar text render blurry). */
+        will-change: transform;
         transition: transform var(--dur) var(--ease);
         padding: 20px 0;
         box-shadow: var(--shadow-lg);
@@ -3786,14 +3790,15 @@ input::placeholder, textarea::placeholder {
     .sidebar__nav { flex-direction: column; }
     .main { padding: 70px 16px 32px; max-width: 100%; }
 
+    /* Solid scrim — no backdrop-filter. iOS Safari + multiple
+       backdrop-filter elements (the page's glass cards plus this scrim)
+       triggered a compositor bug that down-sampled the sidebar above. */
     .sidebar-backdrop {
         display: none;
         position: fixed;
         inset: 0;
         background: var(--overlay-modal);
         z-index: 140;
-        backdrop-filter: blur(2px);
-        -webkit-backdrop-filter: blur(2px);
     }
     .sidebar-backdrop.is-open { display: block; animation: fade-in var(--dur) var(--ease) both; }
 


### PR DESCRIPTION
Closes #135.

iOS Safari co-rasterises adjacent backdrop-filter elements into the same low-DPI compositing layer. Page cards (20px glass blur) plus the sidebar-backdrop's 2px blur down-sampled the open drawer text.

- Drop `backdrop-filter` from `.sidebar-backdrop` — solid scrim is enough.
- Add `will-change: transform` to mobile `.sidebar` so it composites on its own layer.

Desktop sticky sidebar, drawer animation, scrim colour and fade-in are all untouched.