### PR TITLE
fix mobile sidebar clicks

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -3,6 +3,10 @@
 Format tightened on 2026-05-05 to short Keep-a-Changelog style. Earlier
 verbose entries are in git history (`git log -p CHANGELOG.md`).
 
+## [0.6.44] - 2026-05-06
+### Fixed
+- Mobile sidebar links wouldn't respond to taps when the drawer was open. (#138)
+
 ## [0.6.43] - 2026-05-06
 ### Fixed
 - iOS Safari rendered the mobile sidebar text blurry when the drawer opened. (#136)

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -699,6 +699,10 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
 .app-body {
     min-height: 100vh;
     position: relative;
+    /* isolation creates a new stacking context here so the blob can sit at
+       z-index: -1 without falling behind the body bg; meanwhile the sidebar
+       and its backdrop don't get trapped in a child stacking context. */
+    isolation: isolate;
 }
 /* Atmospheric layer behind every authenticated page — three soft radial
    blobs (sage / clay / berry) fixed to the viewport. Provides the colour
@@ -709,7 +713,13 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
     position: fixed;
     inset: 0;
     pointer-events: none;
-    z-index: 0;
+    /* z-index -1 (combined with .app-body's `isolation: isolate`) keeps the
+       blob behind every layout child but in front of the body background.
+       Was z-index: 0, which forced .app-layout to z-index: 1 and trapped
+       the mobile sidebar in a child stacking context — its 150 then sat
+       below the backdrop's 140 in the body context, making the open
+       drawer un-clickable on iOS. */
+    z-index: -1;
     background:
         radial-gradient(80vw 80vh at 12% 10%, rgba(184, 209, 168, 0.30), transparent 55%),
         radial-gradient(70vw 70vh at 88% 92%, rgba(217, 119, 87, 0.16), transparent 60%),
@@ -731,8 +741,6 @@ a:hover { text-decoration: underline; text-decoration-thickness: 1.5px; text-und
             radial-gradient(60vw 60vh at 92% 18%, rgba(74, 37, 48, 0.24), transparent 60%);
     }
 }
-.app-layout { position: relative; z-index: 1; }
-
 .app-layout {
     display: flex;
     min-height: 100vh;


### PR DESCRIPTION
Closes #137.

Sidebar visually appears above the backdrop but tap events fall through to the backdrop. Cause: `.app-layout { z-index: 1 }` (added in v0.6.28 for the blob layer) trapped `.sidebar` in a child stacking context, so its z-index 150 lost the body-level race against the backdrop's 140.

Three changes:
- `.app-body` gets `isolation: isolate` so the blob can use a negative z-index without falling behind the body bg.
- `.app-body::before` z-index 0 → -1.
- Remove the `z-index: 1` from `.app-layout` — no longer needed, blob is below.

Sidebar and backdrop now share one stacking context where 150 > 140. Desktop sticky sidebar, drawer animation, glass cards, and v0.6.43's will-change are all untouched.