### PR TITLE
fix mobile messages layout

### DIFF
--- a/2850final project/CHANGELOG.md
+++ b/2850final project/CHANGELOG.md
@@ -3,6 +3,10 @@
 Format tightened on 2026-05-05 to short Keep-a-Changelog style. Earlier
 verbose entries are in git history (`git log -p CHANGELOG.md`).
 
+## [0.6.46] - 2026-05-06
+### Changed
+- Mobile messages page: single-pane phone UX. Conversation list takes the full screen until you pick someone; opening a conversation hides the rail and shows the chat full-width with a back arrow in the header. (#142)
+
 ## [0.6.45] - 2026-05-06
 ### Fixed
 - iOS Safari layout fixes: 100dvh fallback so URL bar doesn't cut content; 16 px input font so the keyboard doesn't auto-zoom; overscroll-behavior contains modal / chat / picker scrolls. (#140)

--- a/2850final project/src/main/resources/static/css/styles.css
+++ b/2850final project/src/main/resources/static/css/styles.css
@@ -2294,6 +2294,9 @@ input::placeholder, textarea::placeholder {
     justify-content: center;
     min-height: 72px;
 }
+/* Default-hide the mobile back arrow; the @media (max-width: 840px) block
+   below flips it to inline-flex when there's no conversation rail beside. */
+.chat-main__back { display: none; }
 .chat-main__head-body {
     display: flex;
     flex-direction: column;
@@ -3817,13 +3820,41 @@ input::placeholder, textarea::placeholder {
     }
     .sidebar-backdrop.is-open { display: block; animation: fade-in var(--dur) var(--ease) both; }
 
-    .chat-layout { grid-template-columns: 1fr; min-height: auto; }
+    /* Mobile chat — single-pane phone UX. With an active conversation we
+       hide the conversation rail and show the chat full-screen. Without
+       one we hide the empty chat panel and the rail takes the screen. */
+    .chat-layout {
+        grid-template-columns: 1fr;
+        min-height: auto;
+    }
     .chat-sidebar {
         border-right: none;
         border-bottom: 1px solid var(--color-border-soft);
-        max-height: 240px;
+        max-height: none;
         overflow-y: auto;
     }
+    .chat-layout--active .chat-sidebar { display: none; }
+    .chat-layout:not(.chat-layout--active) .chat-main { display: none; }
+
+    /* Back arrow — only on mobile, only inside an active conversation
+       (chat-main__head only renders when activePartnerId != null, so
+       the link doesn't appear on the empty-state header). */
+    .chat-main__back {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        flex-shrink: 0;
+        border-radius: 50%;
+        color: var(--text-strong);
+        text-decoration: none;
+        margin-left: -6px;
+        margin-right: 2px;
+        transition: background var(--dur-fast) var(--ease);
+    }
+    .chat-main__back:hover,
+    .chat-main__back:active { background: var(--color-surface-warm); text-decoration: none; }
 
     .auth-title { font-size: 32px; }
 }

--- a/2850final project/src/main/resources/templates/professional/messages.html
+++ b/2850final project/src/main/resources/templates/professional/messages.html
@@ -33,7 +33,7 @@
             <p class="page-meta">Message your clients</p>
         </header>
 
-        <div class="chat-layout card card--flush">
+        <div class="chat-layout card card--flush" th:classappend="${activePartnerId != null} ? ' chat-layout--active' : ''">
             <aside class="chat-sidebar">
                 <div class="chat-sidebar__head">
                     <h2 class="chat-sidebar__title">Conversations</h2>
@@ -81,6 +81,12 @@
             </aside>
             <section class="chat-main">
                 <header class="chat-main__head" th:if="${activePartnerId != null}">
+                    <a href="/messages" class="chat-main__back" aria-label="Back to conversations">
+                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M15 6 L 9 12 L 15 18"/>
+                        </svg>
+                    </a>
                     <span class="conv-list__avatar conv-list__avatar--lg">
                         <span th:text="${activePartnerInitials}">AB</span>
                         <span class="conv-list__online" aria-hidden="true"></span>

--- a/2850final project/src/main/resources/templates/subscriber/messages.html
+++ b/2850final project/src/main/resources/templates/subscriber/messages.html
@@ -37,7 +37,7 @@
             <p class="page-meta">Chat with your nutrition professional</p>
         </header>
 
-        <div class="chat-layout card card--flush">
+        <div class="chat-layout card card--flush" th:classappend="${activePartnerId != null} ? ' chat-layout--active' : ''">
             <aside class="chat-sidebar">
                 <div class="chat-sidebar__head">
                     <h2 class="chat-sidebar__title">Conversations</h2>
@@ -85,6 +85,12 @@
             </aside>
             <section class="chat-main">
                 <header class="chat-main__head" th:if="${activePartnerId != null}">
+                    <a href="/messages" class="chat-main__back" aria-label="Back to conversations">
+                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M15 6 L 9 12 L 15 18"/>
+                        </svg>
+                    </a>
                     <span class="conv-list__avatar conv-list__avatar--lg">
                         <span th:text="${activePartnerInitials}">AB</span>
                         <span class="conv-list__online" aria-hidden="true"></span>


### PR DESCRIPTION
Closes #141.

## Summary
- Single-pane phone UX: conversation list takes the whole screen until you pick someone.
- Opening a conversation hides the rail and shows the chat full-width with a back arrow in the header.
- Desktop two-pane layout is unchanged.

## How it works
- `chat-layout` gets a `chat-layout--active` class when `activePartnerId` is set.
- Below 840 px: `.chat-layout--active .chat-sidebar { display: none }` and `.chat-layout:not(.chat-layout--active) .chat-main { display: none }`.
- Back arrow `<a href="/messages">` in the chat header is hidden on desktop, shown on mobile.

## Test plan
- [ ] iPhone width: open `/messages`, see only the conversation list
- [ ] Tap a conversation, see the chat full-width with a back arrow
- [ ] Tap the back arrow, return to the list
- [ ] Desktop ≥ 840 px: list and chat still side-by-side, no back arrow